### PR TITLE
feat(ci): main push 時に NetHarvest 本体の Deploy workflow を dispatch

### DIFF
--- a/.github/workflows/notify-deploy.yml
+++ b/.github/workflows/notify-deploy.yml
@@ -1,0 +1,33 @@
+name: Notify NetHarvest deploy
+
+# NetHarvest-Scripts は NetHarvest 本体の ./scripts/ に nested clone されており、
+# 本体側 deploy workflow (sync ジョブ) が origin/main を fetch して反映する。
+# このリポジトリへの push だけでは本体の workflow は起動しないため、
+# 本体の Deploy workflow を REST API で workflow_dispatch する。
+#
+# 必要な secret: DEPLOY_DISPATCH_TOKEN
+#   STREAM-inc/NetHarvest に actions:write 権限を持つ Fine-grained PAT。
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: notify-netharvest-deploy
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger NetHarvest deploy workflow
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Triggered by ${GITHUB_SHA} on ${GITHUB_REF_NAME}"
+          gh workflow run deploy.yml \
+            --repo STREAM-inc/NetHarvest \
+            --ref master
+          echo "Dispatched STREAM-inc/NetHarvest deploy.yml on master"


### PR DESCRIPTION
## Summary
- NetHarvest-Scripts は NetHarvest 本体の `./scripts/` に nested clone されているだけで、本体の Deploy workflow (master push trigger) はこちらの push を直接検知できない
- そのためスクレイピングコード追加・`sites.yml` 編集後に本リポジトリへ push しても、本体での Prefect 再登録・サーバー同期が走らず scripts/ が古いままになる問題があった
- main への push を trigger に、`gh workflow run` で STREAM-inc/NetHarvest の `deploy.yml` を workflow_dispatch する workflow を追加

## Required setup
本リポジトリの `Settings > Secrets and variables > Actions` に以下の secret を登録する必要があります:

| 名前 | 内容 |
|---|---|
| `DEPLOY_DISPATCH_TOKEN` | STREAM-inc/NetHarvest に `actions: write` 権限を持つ Fine-grained PAT |

## Test plan
- [ ] secret 登録後、本 PR を main にマージ
- [ ] 本 PR のマージ自体で notify-deploy.yml の最初の実行が起動し、STREAM-inc/NetHarvest の Deploy ワークフローが連鎖起動すること
- [ ] 以降、main への通常 push (例: sites.yml 編集) で本体 Deploy が自動起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)