### PR TITLE
Add Cookdoor restaurant crawler

### DIFF
--- a/run_cookdoor_merge_to_share.ps1
+++ b/run_cookdoor_merge_to_share.ps1
@@ -1,0 +1,186 @@
+param(
+    [string]$Destination = "",
+    [string]$Prefs = "",
+    [string]$Date = "",
+    [string]$OutputName = "",
+    [datetime]$After = [datetime]::MinValue
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$NetHarvestRoot = Join-Path (Split-Path -Parent $RepoRoot) "NetHarvest"
+$OutputDir = Join-Path $NetHarvestRoot "output"
+
+if (-not $Date) {
+    $Date = Get-Date -Format "yyyyMMdd"
+}
+
+if (-not $Destination) {
+    $jpFolder = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String("5Y+W5b6X44OH44O844K/"))
+    $month = $Date.Substring(0, 6)
+    $Destination = "\\STREAM06\Share\Scraping\$jpFolder\$month\$Date"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+
+$PrefSlugs = @(
+    "hokkaido",
+    "aomori",
+    "iwate",
+    "miyagi",
+    "akita",
+    "yamagata",
+    "fukushima",
+    "ibaraki",
+    "tochigi",
+    "gunma",
+    "saitama",
+    "chiba",
+    "tokyo",
+    "kanagawa",
+    "niigata",
+    "toyama",
+    "ishikawa",
+    "fukui",
+    "yamanashi",
+    "nagano",
+    "gifu",
+    "shizuoka",
+    "aichi",
+    "mie",
+    "shiga",
+    "kyoto",
+    "osaka",
+    "hyogo",
+    "nara",
+    "wakayama",
+    "tottori",
+    "shimane",
+    "okayama",
+    "hiroshima",
+    "yamaguchi",
+    "tokushima",
+    "kagawa",
+    "ehime",
+    "kochi",
+    "fukuoka",
+    "saga",
+    "nagasaki",
+    "kumamoto",
+    "oita",
+    "miyazaki",
+    "kagoshima",
+    "okinawa"
+)
+
+if ($Prefs) {
+    $PrefList = $Prefs.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+} else {
+    $PrefList = $PrefSlugs
+}
+
+$RunTag = Get-Date -Format "yyyyMMdd_HHmmss"
+$MergeLog = Join-Path $OutputDir "cookdoor_merge_$RunTag.log"
+
+function Write-MergeLog {
+    param([string]$Message)
+    $line = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') $Message"
+    $line | Tee-Object -FilePath $MergeLog -Append
+}
+
+function Get-CookdoorPrefCsv {
+    param([string]$Pref)
+
+    Get-ChildItem -LiteralPath $Destination -Filter "$Date*cookdoor*.csv" |
+        Where-Object {
+            $_.LastWriteTime -ge $After -and
+            $_.Name -like "*cookdoor*" -and
+            $_.Name -notlike "*merged*" -and
+            $_.Name -notlike "pipeline_*" -and
+            $_.Name -like "*_${Pref}_*"
+        } |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+}
+
+function Merge-CookdoorCsv {
+    param(
+        [System.IO.FileInfo[]]$Files,
+        [string]$OutputPath
+    )
+
+    $encoding = New-Object System.Text.UTF8Encoding($true)
+    $writer = New-Object System.IO.StreamWriter($OutputPath, $false, $encoding)
+    $rowCount = 0
+    $wroteHeader = $false
+
+    try {
+        foreach ($file in $Files) {
+            $reader = New-Object System.IO.StreamReader($file.FullName, [System.Text.Encoding]::UTF8)
+            try {
+                $header = $reader.ReadLine()
+                if ([string]::IsNullOrWhiteSpace($header)) {
+                    continue
+                }
+                if (-not $wroteHeader) {
+                    $writer.WriteLine($header)
+                    $wroteHeader = $true
+                }
+
+                while (($line = $reader.ReadLine()) -ne $null) {
+                    if ($line.Length -eq 0) {
+                        continue
+                    }
+                    $writer.WriteLine($line)
+                    $rowCount += 1
+                }
+            } finally {
+                $reader.Close()
+            }
+        }
+    } finally {
+        $writer.Close()
+    }
+
+    return $rowCount
+}
+
+Write-MergeLog "Cookdoor merge started. destination=$Destination prefs=$($PrefList -join ',') date=$Date after=$After"
+
+$sourceFiles = @()
+$seenFiles = @{}
+foreach ($pref in $PrefList) {
+    $file = Get-CookdoorPrefCsv -Pref $pref
+    if ($null -eq $file) {
+        Write-MergeLog "source missing. pref=$pref"
+        continue
+    }
+    if (-not $seenFiles.ContainsKey($file.FullName)) {
+        $sourceFiles += $file
+        $seenFiles[$file.FullName] = $true
+        Write-MergeLog "source added. pref=$pref file=$($file.FullName)"
+    }
+}
+
+if ($sourceFiles.Count -eq 0) {
+    Write-MergeLog "No source csv was found."
+    exit 1
+}
+
+if ($OutputName) {
+    if (-not $OutputName.EndsWith(".csv", [System.StringComparison]::OrdinalIgnoreCase)) {
+        $OutputName = "$OutputName.csv"
+    }
+    $targetPath = Join-Path $Destination $OutputName
+    $rowCount = Merge-CookdoorCsv -Files $sourceFiles -OutputPath $targetPath
+} else {
+    $targetBase = "${Date}_cookdoor_merged_all_クックドア_merged"
+    $tempPath = Join-Path $Destination "$targetBase.tmp"
+    $rowCount = Merge-CookdoorCsv -Files $sourceFiles -OutputPath $tempPath
+    $targetPath = Join-Path $Destination "${targetBase}_${rowCount}件.csv"
+    Move-Item -LiteralPath $tempPath -Destination $targetPath -Force
+}
+
+Write-MergeLog "Cookdoor merge finished. files=$($sourceFiles.Count) rows=$rowCount target=$targetPath"

--- a/run_cookdoor_pref_queue.ps1
+++ b/run_cookdoor_pref_queue.ps1
@@ -3,7 +3,9 @@ param(
     [string]$Prefs,
     [string]$Destination = "",
     [int]$PauseSeconds = 60,
-    [string]$Python = "python"
+    [string]$Python = "python",
+    [string]$MergedName = "",
+    [switch]$SkipMerge
 )
 
 $ErrorActionPreference = "Stop"
@@ -24,6 +26,7 @@ New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 New-Item -ItemType Directory -Force -Path $Destination | Out-Null
 
 $QueueTag = Get-Date -Format "yyyyMMdd_HHmmss"
+$QueueStart = Get-Date
 $QueueLog = Join-Path $OutputDir "cookdoor_pref_queue_$QueueTag.log"
 $PrefList = $Prefs.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ }
 
@@ -31,6 +34,112 @@ function Write-QueueLog {
     param([string]$Message)
     $line = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') $Message"
     $line | Tee-Object -FilePath $QueueLog -Append
+}
+
+function Get-CookdoorPrefCsv {
+    param(
+        [string]$Pref,
+        [datetime]$After
+    )
+
+    Get-ChildItem -LiteralPath $Destination -Filter "*.csv" |
+        Where-Object {
+            $_.LastWriteTime -ge $After -and
+            $_.Name -like "*cookdoor*" -and
+            $_.Name -notlike "*merged*" -and
+            $_.Name -notlike "pipeline_*" -and
+            $_.Name -like "*_${Pref}_*"
+        } |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+}
+
+function Merge-CookdoorCsv {
+    param(
+        [System.IO.FileInfo[]]$Files,
+        [string]$OutputPath
+    )
+
+    $encoding = New-Object System.Text.UTF8Encoding($true)
+    $writer = New-Object System.IO.StreamWriter($OutputPath, $false, $encoding)
+    $rowCount = 0
+    $wroteHeader = $false
+
+    try {
+        foreach ($file in $Files) {
+            $reader = New-Object System.IO.StreamReader($file.FullName, [System.Text.Encoding]::UTF8)
+            try {
+                $header = $reader.ReadLine()
+                if ([string]::IsNullOrWhiteSpace($header)) {
+                    continue
+                }
+                if (-not $wroteHeader) {
+                    $writer.WriteLine($header)
+                    $wroteHeader = $true
+                }
+
+                while (($line = $reader.ReadLine()) -ne $null) {
+                    if ($line.Length -eq 0) {
+                        continue
+                    }
+                    $writer.WriteLine($line)
+                    $rowCount += 1
+                }
+            } finally {
+                $reader.Close()
+            }
+        }
+    } finally {
+        $writer.Close()
+    }
+
+    return $rowCount
+}
+
+function Invoke-CookdoorQueueMerge {
+    if ($SkipMerge) {
+        Write-QueueLog "Cookdoor merge skipped."
+        return
+    }
+
+    $sourceFiles = @()
+    $seenFiles = @{}
+    foreach ($pref in $PrefList) {
+        $file = Get-CookdoorPrefCsv -Pref $pref -After $QueueStart
+        if ($null -eq $file) {
+            Write-QueueLog "merge source missing. pref=$pref"
+            continue
+        }
+        if (-not $seenFiles.ContainsKey($file.FullName)) {
+            $sourceFiles += $file
+            $seenFiles[$file.FullName] = $true
+        }
+    }
+
+    if ($sourceFiles.Count -eq 0) {
+        Write-QueueLog "Cookdoor merge skipped because no source csv was found."
+        return
+    }
+
+    $providedName = -not [string]::IsNullOrWhiteSpace($MergedName)
+    if ($providedName) {
+        $targetName = $MergedName
+        if (-not $targetName.EndsWith(".csv", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $targetName = "$targetName.csv"
+        }
+        $targetPath = Join-Path $Destination $targetName
+        $rowCount = Merge-CookdoorCsv -Files $sourceFiles -OutputPath $targetPath
+    } else {
+        $date = Get-Date -Format "yyyyMMdd"
+        $targetBase = "${date}_cookdoor_merged_queue_${QueueTag}_クックドア_merged"
+        $tempPath = Join-Path $Destination "$targetBase.tmp"
+        $rowCount = Merge-CookdoorCsv -Files $sourceFiles -OutputPath $tempPath
+        $targetName = "${targetBase}_${rowCount}件.csv"
+        $targetPath = Join-Path $Destination $targetName
+        Move-Item -LiteralPath $tempPath -Destination $targetPath -Force
+    }
+
+    Write-QueueLog "Cookdoor merge finished. files=$($sourceFiles.Count) rows=$rowCount target=$targetPath"
 }
 
 Write-QueueLog "Cookdoor prefecture queue started. prefs=$($PrefList -join ',') destination=$Destination"
@@ -50,4 +159,5 @@ foreach ($pref in $PrefList) {
     }
 }
 
+Invoke-CookdoorQueueMerge
 Write-QueueLog "Cookdoor prefecture queue finished."

--- a/run_cookdoor_pref_queue.ps1
+++ b/run_cookdoor_pref_queue.ps1
@@ -1,0 +1,53 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Prefs,
+    [string]$Destination = "",
+    [int]$PauseSeconds = 60,
+    [string]$Python = "python"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Runner = Join-Path $RepoRoot "run_cookdoor_to_share.ps1"
+$NetHarvestRoot = Join-Path (Split-Path -Parent $RepoRoot) "NetHarvest"
+$OutputDir = Join-Path $NetHarvestRoot "output"
+
+if (-not $Destination) {
+    $jpFolder = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String("5Y+W5b6X44OH44O844K/"))
+    $month = Get-Date -Format "yyyyMM"
+    $day = Get-Date -Format "yyyyMMdd"
+    $Destination = "\\STREAM06\Share\Scraping\$jpFolder\$month\$day"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+
+$QueueTag = Get-Date -Format "yyyyMMdd_HHmmss"
+$QueueLog = Join-Path $OutputDir "cookdoor_pref_queue_$QueueTag.log"
+$PrefList = $Prefs.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+
+function Write-QueueLog {
+    param([string]$Message)
+    $line = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') $Message"
+    $line | Tee-Object -FilePath $QueueLog -Append
+}
+
+Write-QueueLog "Cookdoor prefecture queue started. prefs=$($PrefList -join ',') destination=$Destination"
+
+foreach ($pref in $PrefList) {
+    Write-QueueLog "pref=$pref start"
+    try {
+        & $Runner -Prefs $pref -Destination $Destination -Python $Python
+        $exitCode = $LASTEXITCODE
+        Write-QueueLog "pref=$pref finished exit=$exitCode"
+    } catch {
+        Write-QueueLog "pref=$pref failed error=$($_.Exception.Message)"
+    }
+
+    if ($PauseSeconds -gt 0) {
+        Start-Sleep -Seconds $PauseSeconds
+    }
+}
+
+Write-QueueLog "Cookdoor prefecture queue finished."

--- a/run_cookdoor_to_share.ps1
+++ b/run_cookdoor_to_share.ps1
@@ -50,8 +50,14 @@ Write-RunLog "Cookdoor scraping started. destination=$Destination repo=$RepoRoot
 $env:PYTHONIOENCODING = "utf-8"
 if ($Prefs) {
     $env:COOKDOOR_PREFS = $Prefs
+    if ($Prefs -notmatch ",") {
+        $env:COOKDOOR_OUTPUT_LABEL = $Prefs
+    } else {
+        Remove-Item Env:\COOKDOOR_OUTPUT_LABEL -ErrorAction SilentlyContinue
+    }
 } else {
     Remove-Item Env:\COOKDOOR_PREFS -ErrorAction SilentlyContinue
+    Remove-Item Env:\COOKDOOR_OUTPUT_LABEL -ErrorAction SilentlyContinue
 }
 if ($MaxItems -gt 0) {
     $env:COOKDOOR_MAX_ITEMS = [string]$MaxItems
@@ -65,20 +71,19 @@ if ($MaxPages -gt 0) {
 }
 
 $attemptLog = Join-Path $OutputDir "cookdoor_to_share_$RunTag.attempt.log"
-$processInfo = New-Object System.Diagnostics.ProcessStartInfo
-$processInfo.FileName = $Python
-$processInfo.Arguments = '"sites/food/cookdoor.py"'
-$processInfo.WorkingDirectory = $RepoRoot
-$processInfo.UseShellExecute = $false
-$processInfo.RedirectStandardOutput = $true
-$processInfo.RedirectStandardError = $true
-$processInfo.CreateNoWindow = $true
-$process = [System.Diagnostics.Process]::Start($processInfo)
-$stdout = $process.StandardOutput.ReadToEnd()
-$stderr = $process.StandardError.ReadToEnd()
-$process.WaitForExit()
+$attemptOutLog = Join-Path $OutputDir "cookdoor_to_share_$RunTag.stdout.log"
+$attemptErrLog = Join-Path $OutputDir "cookdoor_to_share_$RunTag.stderr.log"
+$process = Start-Process -FilePath $Python `
+    -ArgumentList @("sites/food/cookdoor.py") `
+    -WorkingDirectory $RepoRoot `
+    -PassThru `
+    -Wait `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput $attemptOutLog `
+    -RedirectStandardError $attemptErrLog
 $exitCode = $process.ExitCode
-($stdout + $stderr) | Set-Content -LiteralPath $attemptLog -Encoding UTF8
+Get-Content -LiteralPath $attemptOutLog, $attemptErrLog -ErrorAction SilentlyContinue |
+    Set-Content -LiteralPath $attemptLog -Encoding UTF8
 
 Write-RunLog "Cookdoor scraper finished. exit=$exitCode attempt_log=$attemptLog"
 

--- a/run_cookdoor_to_share.ps1
+++ b/run_cookdoor_to_share.ps1
@@ -1,0 +1,98 @@
+param(
+    [string]$Destination = "",
+    [string]$Prefs = "",
+    [int]$MaxItems = 0,
+    [int]$MaxPages = 0,
+    [string]$Python = "python"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$NetHarvestRoot = Join-Path (Split-Path -Parent $RepoRoot) "NetHarvest"
+$OutputDir = Join-Path $NetHarvestRoot "output"
+
+if (-not $Destination) {
+    $jpFolder = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String("5Y+W5b6X44OH44O844K/"))
+    $month = Get-Date -Format "yyyyMM"
+    $day = Get-Date -Format "yyyyMMdd"
+    $Destination = "\\STREAM06\Share\Scraping\$jpFolder\$month\$day"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+
+$RunTag = Get-Date -Format "yyyyMMdd_HHmmss"
+$MainLog = Join-Path $OutputDir "cookdoor_to_share_$RunTag.log"
+$DoneLog = Join-Path $OutputDir "cookdoor_to_share_$RunTag.done.txt"
+$attemptStart = Get-Date
+
+function Write-RunLog {
+    param([string]$Message)
+    $line = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') $Message"
+    $line | Tee-Object -FilePath $MainLog -Append
+}
+
+function Get-FinalCsv {
+    param([datetime]$After)
+    Get-ChildItem -Path $OutputDir -Filter "*.csv" |
+        Where-Object {
+            $_.LastWriteTime -ge $After -and
+            $_.Name -notlike "pipeline_*" -and
+            ($_.Name -like "*cookdoor*" -or $_.Name -like "*クックドア*")
+        } |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+}
+
+Write-RunLog "Cookdoor scraping started. destination=$Destination repo=$RepoRoot"
+
+$env:PYTHONIOENCODING = "utf-8"
+if ($Prefs) {
+    $env:COOKDOOR_PREFS = $Prefs
+} else {
+    Remove-Item Env:\COOKDOOR_PREFS -ErrorAction SilentlyContinue
+}
+if ($MaxItems -gt 0) {
+    $env:COOKDOOR_MAX_ITEMS = [string]$MaxItems
+} else {
+    Remove-Item Env:\COOKDOOR_MAX_ITEMS -ErrorAction SilentlyContinue
+}
+if ($MaxPages -gt 0) {
+    $env:COOKDOOR_MAX_PAGES = [string]$MaxPages
+} else {
+    Remove-Item Env:\COOKDOOR_MAX_PAGES -ErrorAction SilentlyContinue
+}
+
+$attemptLog = Join-Path $OutputDir "cookdoor_to_share_$RunTag.attempt.log"
+$processInfo = New-Object System.Diagnostics.ProcessStartInfo
+$processInfo.FileName = $Python
+$processInfo.Arguments = '"sites/food/cookdoor.py"'
+$processInfo.WorkingDirectory = $RepoRoot
+$processInfo.UseShellExecute = $false
+$processInfo.RedirectStandardOutput = $true
+$processInfo.RedirectStandardError = $true
+$processInfo.CreateNoWindow = $true
+$process = [System.Diagnostics.Process]::Start($processInfo)
+$stdout = $process.StandardOutput.ReadToEnd()
+$stderr = $process.StandardError.ReadToEnd()
+$process.WaitForExit()
+$exitCode = $process.ExitCode
+($stdout + $stderr) | Set-Content -LiteralPath $attemptLog -Encoding UTF8
+
+Write-RunLog "Cookdoor scraper finished. exit=$exitCode attempt_log=$attemptLog"
+
+$csv = Get-FinalCsv -After $attemptStart
+if ($null -eq $csv) {
+    Write-RunLog "No final Cookdoor CSV was produced."
+    exit 1
+}
+
+$target = Join-Path $Destination $csv.Name
+Copy-Item -LiteralPath $csv.FullName -Destination $target -Force
+Write-RunLog "Copied final csv. source=$($csv.FullName) target=$target"
+
+"Copied: $($csv.FullName)`nTo: $target`nAt: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" |
+    Set-Content -LiteralPath $DoneLog -Encoding UTF8
+
+exit $exitCode

--- a/sites.yml
+++ b/sites.yml
@@ -708,6 +708,13 @@ sites:
     schedule: "20 6 1-7 * SUN"
     enabled: true
 
+  - site_id: cookdoor
+    name: "クックドア"
+    module: "food.cookdoor"
+    url: "https://www.cookdoor.jp/"
+    schedule: null
+    enabled: true
+
   - site_id: mypl
     name: "まいぷれ"
     module: "portal.mypl"

--- a/sites.yml
+++ b/sites.yml
@@ -712,7 +712,7 @@ sites:
     name: "クックドア"
     module: "food.cookdoor"
     url: "https://www.cookdoor.jp/"
-    schedule: null
+    schedule: "0 10 1-7 * SUN"
     enabled: true
 
   - site_id: mypl

--- a/sites/food/cookdoor.py
+++ b/sites/food/cookdoor.py
@@ -1,0 +1,526 @@
+"""
+対象サイト: https://www.cookdoor.jp/
+
+クックドア 飲食店情報スクレイパー
+
+取得方針:
+    - 全国一覧では 9999 ページ上限があるため、47都道府県の一覧を巡回する
+    - 口コミ本文や紹介文などの文章は保存せず、基礎情報テーブルと件数のみを取得する
+
+ローカル検証用の環境変数:
+    COOKDOOR_PREFS=tokyo,osaka        # 対象都道府県を絞り込み
+    COOKDOOR_MAX_ITEMS=30             # 最大取得件数
+    COOKDOOR_MAX_PAGES=2              # 都道府県ごとの最大一覧ページ数
+"""
+
+import math
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Generator
+from urllib.parse import parse_qs, urljoin, urlparse
+
+import bs4
+
+_here = Path(__file__).resolve()
+for _candidate in (
+    _here.parents[3],
+    _here.parents[3] / "NetHarvest",
+    _here.parents[3].parent / "NetHarvest",
+):
+    if (_candidate / "src").exists():
+        if str(_candidate) not in sys.path:
+            sys.path.insert(0, str(_candidate))
+        break
+
+from src.const.schema import Schema
+from src.framework.static import StaticCrawler
+
+
+BASE_URL = "https://www.cookdoor.jp"
+MEDIA_NAME = "クックドア"
+PAGE_SIZE = 30
+
+PREFECTURES = [
+    ("hokkaido", "北海道"),
+    ("aomori", "青森県"),
+    ("iwate", "岩手県"),
+    ("miyagi", "宮城県"),
+    ("akita", "秋田県"),
+    ("yamagata", "山形県"),
+    ("fukushima", "福島県"),
+    ("ibaraki", "茨城県"),
+    ("tochigi", "栃木県"),
+    ("gunma", "群馬県"),
+    ("saitama", "埼玉県"),
+    ("chiba", "千葉県"),
+    ("tokyo", "東京都"),
+    ("kanagawa", "神奈川県"),
+    ("niigata", "新潟県"),
+    ("toyama", "富山県"),
+    ("ishikawa", "石川県"),
+    ("fukui", "福井県"),
+    ("yamanashi", "山梨県"),
+    ("nagano", "長野県"),
+    ("gifu", "岐阜県"),
+    ("shizuoka", "静岡県"),
+    ("aichi", "愛知県"),
+    ("mie", "三重県"),
+    ("shiga", "滋賀県"),
+    ("kyoto", "京都府"),
+    ("osaka", "大阪府"),
+    ("hyogo", "兵庫県"),
+    ("nara", "奈良県"),
+    ("wakayama", "和歌山県"),
+    ("tottori", "鳥取県"),
+    ("shimane", "島根県"),
+    ("okayama", "岡山県"),
+    ("hiroshima", "広島県"),
+    ("yamaguchi", "山口県"),
+    ("tokushima", "徳島県"),
+    ("kagawa", "香川県"),
+    ("ehime", "愛媛県"),
+    ("kochi", "高知県"),
+    ("fukuoka", "福岡県"),
+    ("saga", "佐賀県"),
+    ("nagasaki", "長崎県"),
+    ("kumamoto", "熊本県"),
+    ("oita", "大分県"),
+    ("miyazaki", "宮崎県"),
+    ("kagoshima", "鹿児島県"),
+    ("okinawa", "沖縄県"),
+]
+
+PREF_PATTERN = re.compile(
+    r"^(北海道|青森県|岩手県|宮城県|秋田県|山形県|福島県|"
+    r"茨城県|栃木県|群馬県|埼玉県|千葉県|東京都|神奈川県|"
+    r"新潟県|富山県|石川県|福井県|山梨県|長野県|岐阜県|静岡県|愛知県|"
+    r"三重県|滋賀県|京都府|大阪府|兵庫県|奈良県|和歌山県|"
+    r"鳥取県|島根県|岡山県|広島県|山口県|"
+    r"徳島県|香川県|愛媛県|高知県|"
+    r"福岡県|佐賀県|長崎県|熊本県|大分県|宮崎県|鹿児島県|沖縄県)"
+)
+ZIP_PATTERN = re.compile(r"〒?\s*(\d{3}-\d{4})")
+TOTAL_COUNT_PATTERN = re.compile(r"[\/／]\s*([\d,]+)\s*店舗")
+DETAIL_PATH_PATTERN = re.compile(r"^/dtl/\d+/$")
+WS_PATTERN = re.compile(r"\s+")
+ORDER_STOP_PATTERN = re.compile(r"オーダーストップ\s*([^\)）\s]+(?:\s*[0-9:：]+)?)")
+
+CATEGORY_LV2_MAP = {
+    "ファミレス": "レストラン・食堂",
+    "ファーストフード": "ファストフード",
+    "ステーキハウス": "洋食・レストラン",
+    "レストラン": "洋食・レストラン",
+    "和食・日本料理": "和食",
+    "うどん・そば屋": "麺類",
+    "寿司": "寿司",
+    "居酒屋": "居酒屋",
+    "お好み焼き": "粉もの",
+    "焼肉・韓国料理": "焼肉・韓国料理",
+    "中華料理・中国料理": "中華料理",
+    "ラーメン": "ラーメン",
+    "喫茶店・カフェ": "カフェ・喫茶",
+}
+
+
+class CookdoorScraper(StaticCrawler):
+    """クックドア 飲食店情報スクレイパー"""
+
+    USER_AGENT = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/136.0.0.0 Safari/537.36"
+    )
+    TIMEOUT = 30
+    DELAY = 1.0
+    LIST_DELAY = 0.7
+    EXTRA_COLUMNS = [
+        "掲載媒体名",
+        "エリア",
+        "交通アクセス",
+        "平均予算",
+        "座席",
+        "予約",
+        "貸切",
+        "禁煙・喫煙",
+        "駐車場",
+        "カード",
+        "口コミ数",
+        "写真数",
+        "動画数",
+        "緯度",
+        "経度",
+        "オーダーストップ",
+        "名寄せキー",
+        "取得元一覧URL",
+    ]
+
+    def parse(self, url: str) -> Generator[dict, None, None]:
+        max_items = _int_env("COOKDOOR_MAX_ITEMS")
+        max_pages = _int_env("COOKDOOR_MAX_PAGES")
+        selected_prefs = self._select_prefectures(url)
+
+        pref_pages: list[tuple[str, str, int, bs4.BeautifulSoup]] = []
+        estimated_total = 0
+        for slug, pref_name in selected_prefs:
+            list_url = self._list_url(slug, 1)
+            soup = self.get_soup(list_url)
+            if soup is None:
+                self.logger.warning("都道府県一覧取得失敗: %s", list_url)
+                continue
+            total_count = self._extract_total_count(soup)
+            if total_count == 0:
+                self.logger.warning("総件数を取得できませんでした: %s", list_url)
+            estimated_total += total_count
+            pref_pages.append((slug, pref_name, total_count, soup))
+            self.logger.info("%s: 推定 %d 件", pref_name, total_count)
+            time.sleep(self.LIST_DELAY)
+
+        self.total_items = min(estimated_total, max_items) if max_items else estimated_total
+        self.logger.info("取得対象推定: %d 件", self.total_items or 0)
+
+        yielded = 0
+        seen: set[str] = set()
+        for slug, pref_name, total_count, first_soup in pref_pages:
+            page_count = max(1, math.ceil(total_count / PAGE_SIZE)) if total_count else 1
+            if max_pages:
+                page_count = min(page_count, max_pages)
+
+            for page_no in range(1, page_count + 1):
+                list_url = self._list_url(slug, page_no)
+                soup = first_soup if page_no == 1 else self.get_soup(list_url)
+                if soup is None:
+                    self.logger.warning("一覧ページ取得失敗: %s", list_url)
+                    break
+
+                detail_urls = self._extract_detail_urls(soup)
+                if not detail_urls:
+                    self.logger.info("詳細URLなしで終了: %s", list_url)
+                    break
+
+                self.logger.info(
+                    "%s page=%d/%d: 詳細URL %d 件",
+                    pref_name,
+                    page_no,
+                    page_count,
+                    len(detail_urls),
+                )
+
+                for detail_url in detail_urls:
+                    if detail_url in seen:
+                        continue
+                    seen.add(detail_url)
+
+                    item = self._scrape_detail(detail_url, pref_name, list_url)
+                    if item:
+                        yield item
+                        yielded += 1
+                        if max_items and yielded >= max_items:
+                            return
+
+                if page_no < page_count:
+                    time.sleep(self.LIST_DELAY)
+
+    def _select_prefectures(self, url: str) -> list[tuple[str, str]]:
+        pref_by_slug = dict(PREFECTURES)
+        pref_by_name = {name: (slug, name) for slug, name in PREFECTURES}
+
+        env_value = os.getenv("COOKDOOR_PREFS", "").strip()
+        if env_value:
+            selected = []
+            for raw in env_value.split(","):
+                key = raw.strip()
+                if not key:
+                    continue
+                if key in pref_by_slug:
+                    selected.append((key, pref_by_slug[key]))
+                elif key in pref_by_name:
+                    selected.append(pref_by_name[key])
+                else:
+                    self.logger.warning("未知の都道府県指定をスキップ: %s", key)
+            return selected or PREFECTURES
+
+        path_parts = [p for p in urlparse(url).path.split("/") if p]
+        if path_parts and path_parts[0] in pref_by_slug:
+            slug = path_parts[0]
+            return [(slug, pref_by_slug[slug])]
+        return PREFECTURES
+
+    def _list_url(self, slug: str, page_no: int) -> str:
+        if page_no <= 1:
+            return f"{BASE_URL}/{slug}/list/"
+        return f"{BASE_URL}/{slug}/list/{page_no}/"
+
+    def _extract_total_count(self, soup: bs4.BeautifulSoup) -> int:
+        text = self._clean(soup.get_text(" ", strip=True))
+        match = TOTAL_COUNT_PATTERN.search(text)
+        if not match:
+            return 0
+        return int(match.group(1).replace(",", ""))
+
+    def _extract_detail_urls(self, soup: bs4.BeautifulSoup) -> list[str]:
+        urls = []
+        seen = set()
+        for a in soup.find_all("a", href=True):
+            href = a["href"].strip()
+            detail_url = urljoin(BASE_URL, href)
+            parsed = urlparse(detail_url)
+            if parsed.netloc != "www.cookdoor.jp":
+                continue
+            if not DETAIL_PATH_PATTERN.match(parsed.path):
+                continue
+            normalized = f"{BASE_URL}{parsed.path}"
+            if normalized not in seen:
+                seen.add(normalized)
+                urls.append(normalized)
+        return urls
+
+    def _scrape_detail(self, detail_url: str, pref_hint: str, list_url: str) -> dict | None:
+        soup = self.get_soup(detail_url)
+        if soup is None:
+            return None
+
+        fields, field_cells = self._extract_fields(soup)
+        location_info = self._extract_location_info(soup)
+
+        data = {
+            Schema.URL: detail_url,
+            Schema.CAT_LV1: "飲食",
+            "掲載媒体名": MEDIA_NAME,
+            "取得元一覧URL": list_url,
+        }
+
+        name = fields.get("店名") or self._text_first(soup, "h1")
+        if name:
+            data[Schema.NAME] = name
+
+        pref, address, post_code = self._split_address(fields.get("所在地", ""))
+        data[Schema.PREF] = pref or location_info.get("pref") or pref_hint
+        if post_code:
+            data[Schema.POST_CODE] = post_code
+        if address:
+            data[Schema.ADDR] = address
+
+        area = location_info.get("area")
+        if area:
+            data["エリア"] = area
+
+        tel = self._valid_value(fields.get("TEL", ""))
+        if tel:
+            data[Schema.TEL] = tel
+
+        category = location_info.get("category")
+        if category:
+            data[Schema.CAT_SITE] = category
+            data[Schema.CAT_LV2] = CATEGORY_LV2_MAP.get(category, "飲食店")
+            data[Schema.CAT_LV3] = category
+
+        label_to_schema = {
+            "営業時間": Schema.TIME,
+            "定休日": Schema.HOLIDAY,
+        }
+        for label, schema_key in label_to_schema.items():
+            value = self._valid_value(fields.get(label, ""))
+            if value:
+                data[schema_key] = value
+
+        extra_label_map = {
+            "交通アクセス": "交通アクセス",
+            "平均予算": "平均予算",
+            "座席": "座席",
+            "席数": "座席",
+            "予約": "予約",
+            "貸切": "貸切",
+            "禁煙/喫煙": "禁煙・喫煙",
+            "禁煙・喫煙": "禁煙・喫煙",
+            "駐車場": "駐車場",
+            "カード": "カード",
+        }
+        for label, out_col in extra_label_map.items():
+            value = self._valid_value(fields.get(label, ""))
+            if value and not data.get(out_col):
+                data[out_col] = value
+
+        if data.get("カード"):
+            data[Schema.PAYMENTS] = data["カード"]
+
+        order_stop = self._extract_order_stop(data.get(Schema.TIME, ""))
+        if order_stop:
+            data["オーダーストップ"] = order_stop
+
+        counts = self._extract_counts(soup)
+        data.update(counts)
+
+        coords = self._extract_coordinates(soup)
+        if coords:
+            data["緯度"], data["経度"] = coords
+
+        hp = self._extract_homepage(field_cells.get("ホームページ"), detail_url)
+        if hp:
+            data[Schema.HP] = hp
+
+        if not data.get(Schema.TEL):
+            match_key_parts = [data.get(Schema.NAME, ""), data.get(Schema.PREF, ""), data.get(Schema.ADDR, "")]
+            match_key = self._clean(" ".join(p for p in match_key_parts if p))
+            if match_key:
+                data["名寄せキー"] = match_key
+
+        if not data.get(Schema.NAME):
+            return None
+        return data
+
+    def _extract_fields(self, soup: bs4.BeautifulSoup) -> tuple[dict[str, str], dict[str, bs4.Tag]]:
+        fields: dict[str, str] = {}
+        field_cells: dict[str, bs4.Tag] = {}
+        for table in soup.find_all("table"):
+            classes = table.get("class") or []
+            if "table01" not in classes:
+                continue
+            for tr in table.find_all("tr"):
+                cells = [c for c in tr.find_all(["th", "td"], recursive=False)]
+                for idx in range(0, len(cells) - 1):
+                    if cells[idx].name != "th" or cells[idx + 1].name != "td":
+                        continue
+                    label = self._clean(cells[idx].get_text(" ", strip=True))
+                    value = self._clean_cell_value(label, cells[idx + 1])
+                    if label and value and label not in fields:
+                        fields[label] = value
+                        field_cells[label] = cells[idx + 1]
+        return fields, field_cells
+
+    def _extract_location_info(self, soup: bs4.BeautifulSoup) -> dict[str, str]:
+        info: dict[str, str] = {}
+        el = soup.select_one("p.ttl_location")
+        if not el:
+            return info
+        text = self._clean(el.get_text(" ", strip=True)).strip("（）() ")
+        if "／" in text:
+            area_text, category = [self._clean(part) for part in text.split("／", 1)]
+        elif "/" in text:
+            area_text, category = [self._clean(part) for part in text.split("/", 1)]
+        else:
+            area_text, category = text, ""
+
+        pref_match = PREF_PATTERN.match(area_text)
+        if pref_match:
+            info["pref"] = pref_match.group(1)
+            area = area_text[pref_match.end():].strip()
+            if area:
+                info["area"] = area
+        elif area_text:
+            info["area"] = area_text
+
+        if category:
+            info["category"] = category.strip("（）() ")
+        return info
+
+    def _split_address(self, raw_address: str) -> tuple[str, str, str]:
+        text = self._clean(raw_address.replace("地図を見る", ""))
+        if not text:
+            return "", "", ""
+
+        post_code = ""
+        zip_match = ZIP_PATTERN.search(text)
+        if zip_match:
+            post_code = zip_match.group(1)
+            text = self._clean(text[: zip_match.start()] + " " + text[zip_match.end() :])
+
+        text = text.lstrip("〒").strip()
+        pref = ""
+        pref_match = PREF_PATTERN.match(text)
+        if pref_match:
+            pref = pref_match.group(1)
+            text = text[pref_match.end():].strip()
+        return pref, text, post_code
+
+    def _clean_cell_value(self, label: str, cell: bs4.Tag) -> str:
+        text = cell.get_text(" ", strip=True)
+        if label == "交通アクセス":
+            text = re.split(r"※|実際の正確な道路距離|経路検索", text)[0]
+        return self._clean(text)
+
+    def _extract_order_stop(self, hours: str) -> str:
+        match = ORDER_STOP_PATTERN.search(hours)
+        if not match:
+            return ""
+        return self._clean(match.group(1))
+
+    def _extract_counts(self, soup: bs4.BeautifulSoup) -> dict[str, str]:
+        text = self._clean(soup.get_text(" ", strip=True))
+        result: dict[str, str] = {}
+        patterns = {
+            "口コミ数": r"口コミ\s*([\d,]+)件",
+            "写真数": r"写真\s*([\d,]+)枚",
+            "動画数": r"動画\s*([\d,]+)本",
+        }
+        for col, pattern in patterns.items():
+            match = re.search(pattern, text)
+            if match:
+                result[col] = match.group(1).replace(",", "")
+        return result
+
+    def _extract_coordinates(self, soup: bs4.BeautifulSoup) -> tuple[str, str] | None:
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "destination=" not in href:
+                continue
+            parsed = urlparse(href)
+            destination = parse_qs(parsed.query).get("destination", [""])[0]
+            if "," not in destination:
+                continue
+            lat, lng = [p.strip() for p in destination.split(",", 1)]
+            if lat and lng:
+                return lat, lng
+        return None
+
+    def _extract_homepage(self, cell: bs4.Tag | None, detail_url: str) -> str:
+        if cell is None:
+            return ""
+        for a in cell.find_all("a", href=True):
+            href = urljoin(detail_url, a["href"].strip())
+            parsed = urlparse(href)
+            if parsed.netloc and "cookdoor.jp" not in parsed.netloc and "homemate-research" not in parsed.netloc:
+                return href
+        return ""
+
+    def _text_first(self, soup: bs4.BeautifulSoup, selector: str) -> str:
+        el = soup.select_one(selector)
+        return self._clean(el.get_text(" ", strip=True)) if el else ""
+
+    def _valid_value(self, value: str) -> str:
+        value = self._clean(value)
+        if value in {"", "-", "―", "ー"}:
+            return ""
+        return value
+
+    @staticmethod
+    def _clean(text: str) -> str:
+        return WS_PATTERN.sub(" ", text or "").strip()
+
+
+def _int_env(name: str) -> int | None:
+    raw_value = os.getenv(name, "").strip()
+    if not raw_value:
+        return None
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    scraper = CookdoorScraper()
+    scraper.site_id = "cookdoor"
+    scraper.site_name = "クックドア"
+    scraper.execute("https://www.cookdoor.jp/")
+    print(f"\n出力ファイル: {scraper.output_filepath}")
+    print(f"取得件数: {scraper.item_count}")

--- a/sites/food/cookdoor.py
+++ b/sites/food/cookdoor.py
@@ -162,28 +162,23 @@ class CookdoorScraper(StaticCrawler):
         max_pages = _int_env("COOKDOOR_MAX_PAGES")
         selected_prefs = self._select_prefectures(url)
 
-        pref_pages: list[tuple[str, str, int, bs4.BeautifulSoup]] = []
-        estimated_total = 0
-        for slug, pref_name in selected_prefs:
-            list_url = self._list_url(slug, 1)
-            soup = self.get_soup(list_url)
-            if soup is None:
-                self.logger.warning("都道府県一覧取得失敗: %s", list_url)
-                continue
-            total_count = self._extract_total_count(soup)
-            if total_count == 0:
-                self.logger.warning("総件数を取得できませんでした: %s", list_url)
-            estimated_total += total_count
-            pref_pages.append((slug, pref_name, total_count, soup))
-            self.logger.info("%s: 推定 %d 件", pref_name, total_count)
-            time.sleep(self.LIST_DELAY)
-
-        self.total_items = min(estimated_total, max_items) if max_items else estimated_total
-        self.logger.info("取得対象推定: %d 件", self.total_items or 0)
-
         yielded = 0
+        estimated_total = 0
         seen: set[str] = set()
-        for slug, pref_name, total_count, first_soup in pref_pages:
+        for slug, pref_name in selected_prefs:
+            first_list_url = self._list_url(slug, 1)
+            first_soup = self.get_soup(first_list_url)
+            if first_soup is None:
+                self.logger.warning("都道府県一覧取得失敗: %s", first_list_url)
+                continue
+
+            total_count = self._extract_total_count(first_soup)
+            if total_count == 0:
+                self.logger.warning("総件数を取得できませんでした: %s", first_list_url)
+            estimated_total += total_count
+            self.total_items = min(estimated_total, max_items) if max_items else estimated_total
+            self.logger.info("%s: 推定 %d 件 (累計推定 %d 件)", pref_name, total_count, self.total_items or 0)
+
             page_count = max(1, math.ceil(total_count / PAGE_SIZE)) if total_count else 1
             if max_pages:
                 page_count = min(page_count, max_pages)
@@ -519,8 +514,9 @@ if __name__ == "__main__":
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
     scraper = CookdoorScraper()
-    scraper.site_id = "cookdoor"
-    scraper.site_name = "クックドア"
+    output_label = re.sub(r"[^0-9A-Za-z_-]+", "_", os.getenv("COOKDOOR_OUTPUT_LABEL", "").strip())
+    scraper.site_id = f"cookdoor_{output_label}" if output_label else "cookdoor"
+    scraper.site_name = f"クックドア_{output_label}" if output_label else "クックドア"
     scraper.execute("https://www.cookdoor.jp/")
     print(f"\n出力ファイル: {scraper.output_filepath}")
     print(f"取得件数: {scraper.item_count}")


### PR DESCRIPTION
## Summary
- Add Cookdoor crawler for nationwide restaurant listings
- Register cookdoor in sites.yml as manual schedule
- Add PowerShell helper to copy final CSV to \\STREAM06 share date folder

## Verification
- python -m py_compile sites/food/cookdoor.py
- run_cookdoor_to_share.ps1 -Prefs tokyo -MaxPages 1 -MaxItems 3 copied CSV to share folder

## Notes
- Full run was not started; current verified total is 326,662 restaurants.
- Terms page remained 403, robots.txt does not globally disallow generic crawlers, but site has bot-specific disallows.