### PR TITLE
sites.yml: terms_url に利用規約URLを設定

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -23,7 +23,7 @@ sites:
     url: "https://www.inuki-honpo.jp/rent/?s_prf_cd%5B%5D=13&s_inuki_type%5B%5D=1&s_inuki_category%5B%5D=26&s_city_cd%5B%5D=13101&s_city_cd%5B%5D=13102&s_city_cd%5B%5D=13103&s_city_cd%5B%5D=13104&s_city_cd%5B%5D=13109&s_city_cd%5B%5D=13110&s_city_cd%5B%5D=13112&s_city_cd%5B%5D=13113&s_city_cd%5B%5D=13114&s_city_cd%5B%5D=13115&s_city_cd%5B%5D=13116&s_city_cd%5B%5D=13203&s_walk=&s_tsubo_max=&s_kakaku_m=&s_freeword="
     schedule: "30 9 * * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.inuki-honpo.jp/terms/"
 
   - site_id: beautyworld_japan_tokyo
     name: "Beautyworld Japan Tokyo"
@@ -31,7 +31,7 @@ sites:
     url: "https://beautyworld-japan.jp.messefrankfurt.com/tokyo/ja/exhibitor-search.html"
     schedule: "0 1 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://beautyworld-japan.jp.messefrankfurt.com/tokyo/ja/footer/imprint.html"
 
   - site_id: furugi_meguru
     name: "古着屋巡りマップガイド MEGURU"
@@ -39,7 +39,7 @@ sites:
     url: "https://furugi-meguru.com/"
     schedule: "0 1 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://furugi-meguru.com/termsofservice/"
 
   - site_id: eaidem
     name: "イーアイデム"
@@ -47,7 +47,7 @@ sites:
     url: "https://www.e-aidem.com/aps/list.htm?region_id=06&district_id=31"
     schedule: "0 1 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.e-aidem.com/contents/info/kiyaku.htm"
 
   - site_id: yorushoku
     name: "夜職倶楽部" 
@@ -55,7 +55,7 @@ sites:
     url: "https://yorushoku.jp/job-list/"
     schedule: "0 3 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://yorushoku.jp/terms-of-service/"
 
   - site_id: shinq_compass
     name: "鍼灸コンパス"
@@ -63,7 +63,7 @@ sites:
     url: "https://www.shinq-compass.jp/area/list/?page=1"
     schedule: "0 1 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.shinq-compass.jp/info/kiyaku"
 
   - site_id: imitsu_sales_agent
     name: "PRONIアイミツ_営業代行"
@@ -71,7 +71,7 @@ sites:
     url: "https://imitsu.jp/ct-sales-agent/search/"
     schedule: "0 1 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://imitsu.jp/terms/"
 
   - site_id: biz_sales_outsourcing
     name: "比較ビズ_営業代行"
@@ -79,7 +79,7 @@ sites:
     url: "https://www.biz.ne.jp/list/sales-outsourcing/"
     schedule: "0 1 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.biz.ne.jp/help/regulation.html"
 
   - site_id: reshop-navi
     name: "リショップナビ"
@@ -87,7 +87,7 @@ sites:
     url: "https://rehome-navi.com/shops"
     schedule: "0 1 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://rehome-navi.com/informations/terms"
 
   - site_id: shisha-suitai
     name: "シーシャスイタイ"
@@ -95,7 +95,7 @@ sites:
     url: "https://shisha-suitai.com/sitemap.xml"
     schedule: "0 1 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://shisha-suitai.com/service_term"
 
   - site_id: refonavi
     name: "リフォーム評価ナビ"
@@ -103,7 +103,7 @@ sites:
     url: "https://www.refonavi.or.jp"
     schedule: "0 1 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.refonavi.or.jp/tos"
 
   - site_id: nihon_ryoko_kyokai
     name: "日本旅館協会"
@@ -111,7 +111,7 @@ sites:
     url: "https://www.tour.ne.jp/ext/yadonihon/j_hotel/list/?refpage=form"
     schedule: "0 2 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ryokan.or.jp/sitepolicy/"
 
   - site_id: hairlog
     name: "HAIRLOG"
@@ -119,7 +119,7 @@ sites:
     url: "https://hairlog.jp/sitemap.xml"
     schedule: "20 1 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://hairlog.jp/terms"
 
   - site_id: rakuten_beauty
     name: "楽天ビューティ"
@@ -127,7 +127,7 @@ sites:
     url: "https://beauty.rakuten.co.jp/sitemap.xml"
     schedule: "20 1 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://beauty.rakuten.co.jp/cnt/terms/"
 
   - site_id: minimo
     name: "ミニモ"
@@ -135,7 +135,7 @@ sites:
     url: "https://minimodel.jp/"
     schedule: "50 1 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://minimodel.jp/policy/minimo"
 
   - site_id: goonet
     name: "グーネット"
@@ -143,7 +143,7 @@ sites:
     url: "https://www.goo-net.com/sitemap_index.xml.gz"
     schedule: "20 1 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.goo-net.com/info/tos.html"
 
   - site_id: ii_ie
     name: "いい部屋ネット"
@@ -151,7 +151,7 @@ sites:
     url: "https://www.ii-ie2.net/sitemap.xml"
     schedule: "20 1 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.eheya.net/contents/terms/"
 
   - site_id: ielove
     name: "いえらぶ"
@@ -159,7 +159,7 @@ sites:
     url: "https://www.ielove.co.jp/sitemap/sitemap-company.xml"
     schedule: "20 1 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ielove.co.jp/rules/"
 
   - site_id: ju_ren
     name: "充レン"
@@ -167,7 +167,7 @@ sites:
     url: "https://ju-ren.jp/location/stands/"
     schedule: "20 1 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://ju-ren.jp/terms/"
 
   - site_id: franchise_web_repo
     name: "フランチャイズWEBリポート"
@@ -175,7 +175,7 @@ sites:
     url: "https://web-repo.jp/sitemap.xml"
     schedule: "20 1 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://web-repo.jp/etc/agreement"
 
   - site_id: yourmystar
     name: "ユアマイスター"
@@ -183,7 +183,7 @@ sites:
     url: "https://yourmystar.jp/sitemap.xml"
     schedule: "40 1 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://yourmystar.jp/terms/"
 
   - site_id: meetsmore
     name: "ミツモア"
@@ -191,7 +191,7 @@ sites:
     url: "https://meetsmore.com/services"
     schedule: "40 1 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://meetsmore.com/policies/terms"
 
   - site_id: bilax_net
     name: "びらくネット"
@@ -199,7 +199,7 @@ sites:
     url: "https://bilax.net/sitemap.xml"
     schedule: "40 1 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://bilax.net/usr_kiyaku.cgi"
 
   - site_id: dokenchiku
     name: "ドケンチク"
@@ -207,7 +207,7 @@ sites:
     url: "https://dokenchiku.com/company/1"
     schedule: "40 1 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: koujishi
     name: "工事士.com"
@@ -215,7 +215,7 @@ sites:
     url: "https://koujishi.com/list/denkikoujishi-first/"
     schedule: "40 1 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://koujishi.com/page/rules/"
 
   - site_id: dairitenfc
     name: "代理店FC"
@@ -223,7 +223,7 @@ sites:
     url: "https://dairitenfc.com"
     schedule: "40 1 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://dairitenfc.com/rules/index.html"
 
   - site_id: hakkosha
     name: "白光舎"
@@ -231,7 +231,7 @@ sites:
     url: "https://www.hakkosha.com/shop/"
     schedule: "40 1 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://hakkousya.co.jp/privacy/"
 
   - site_id: hitosara
     name: "ヒトサラ"
@@ -239,7 +239,7 @@ sites:
     url: "https://hitosara.com/sitemap_index.xml"
     schedule: "40 1 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://usen.media/rules/hitosara/"
 
   - site_id: doctor_map
     name: "ドクターマップ"
@@ -247,7 +247,7 @@ sites:
     url: "https://www.doctor-map.info/sitemap.xml"
     schedule: "0 2 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.homemate-research.com/info/rule/"
 
   - site_id: torabayu
     name: "とらばーゆ"
@@ -255,7 +255,7 @@ sites:
     url: "https://toranet.jp/prefectures/"
     schedule: "0 2 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/trn-t-1002/index.html"
 
   - site_id: million_job
     name: "ミリオンジョブ"
@@ -263,7 +263,7 @@ sites:
     url: "https://www.million-job.com"
     schedule: "0 2 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.million-job.com/terms/"
 
   - site_id: refjob
     name: "リフラクジョブ"
@@ -271,7 +271,7 @@ sites:
     url: "https://refjob.jp"
     schedule: "0 2 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://refjob.jp/terms"
 
   - site_id: tainyu_chocolat
     name: "体入ショコラ"
@@ -279,7 +279,7 @@ sites:
     url: "https://chocolat.work/sitemap_index.xml"
     schedule: "10 18 * * TUE"
     enabled: true
-    terms_url: ""
+    terms_url: "https://chocolat.work/terms/"
 
   - site_id: tainyu_macaron
     name: "体入マカロン"
@@ -287,7 +287,7 @@ sites:
     url: "https://picsastock.com/sitemap.xml"
     schedule: "0 2 * * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: tadaoka_shoko
     name: "忠岡町商工会"
@@ -295,7 +295,7 @@ sites:
     url: "https://www.tadaoka.or.jp/kaiin.html"
     schedule: "0 2 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.tadaoka.or.jp/kojinjyouhou.html"
 
   - site_id: bepro
     name: "美プロ"
@@ -303,7 +303,7 @@ sites:
     url: "https://www.kenkou-job.com"
     schedule: "0 2 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.kenkou-job.com/about/terms.html"
 
   - site_id: yakukyari
     name: "薬キャリ（法人）"
@@ -311,7 +311,7 @@ sites:
     url: "https://pcareer.m3.com/shokubanavi/companies"
     schedule: "20 2 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://pcareer.m3.com/shokubanavi/terms_of_service"
 
   - site_id: yakukyari_office
     name: "薬キャリ（事業所）"
@@ -319,7 +319,7 @@ sites:
     url: "https://pcareer.m3.com/shokubanavi/offices"
     schedule: "20 2 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://pcareer.m3.com/shokubanavi/terms_of_service"
 
   - site_id: kaiten_heiten
     name: "開店閉店ドットコム"
@@ -327,7 +327,7 @@ sites:
     url: "https://kaiten-heiten-24.com"
     schedule: "20 2 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://kaiten-heiten.com/index.php/privacy-policy/"
 
   - site_id: inshokuten_job
     name: "求人飲食店ドットコム"
@@ -335,7 +335,7 @@ sites:
     url: "https://job.inshokuten.com/sitemapindex.xml"
     schedule: "20 2 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://job.inshokuten.com/term"
 
   - site_id: paypaygourmet
     name: "PayPayグルメ"
@@ -343,7 +343,7 @@ sites:
     url: "https://paypaygourmet.yahoo.co.jp/"
     schedule: "0 1 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.lycorp.co.jp/ja/company/terms/"
 
   - site_id: suumo
     name: "SUUMO不動産会社"
@@ -351,7 +351,7 @@ sites:
     url: "https://suumo.jp/kaisha/"
     schedule: "20 2 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/suu-t-1003/index.html"
 
   - site_id: suumo_buy
     name: "SUUMO新築・中古物件"
@@ -359,7 +359,7 @@ sites:
     url: "https://suumo.jp/ms/shinchiku/"
     schedule: "20 2 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/suu-t-1003/index.html"
 
   - site_id: suumo_guide
     name: "SUUMO不動産会社ガイド"
@@ -367,7 +367,7 @@ sites:
     url: "https://suumo.jp/jj/guide/"
     schedule: "20 2 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/suu-t-1003/index.html"
 
   - site_id: yameshi_shokokai
     name: "八女市商工会"
@@ -375,7 +375,7 @@ sites:
     url: "https://www.yameshi-shokokai.jp/member/"
     schedule: "20 2 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.yameshi-shokokai.jp/pp/"
 
   - site_id: ogori_shokokai
     name: "小郡市商工会"
@@ -383,7 +383,7 @@ sites:
     url: "https://ogori-shoukoukai.com/companycat/"
     schedule: "40 2 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://ogori-shoukoukai.com/privacy/"
 
   - site_id: kawachinagano_shokokai
     name: "河内長野市商工会"
@@ -391,7 +391,7 @@ sites:
     url: "http://www.ksci.or.jp/web.html"
     schedule: "40 2 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "http://www.ksci.or.jp/privacy.html"
 
   - site_id: ai_med
     name: "アイメッド"
@@ -399,7 +399,7 @@ sites:
     url: "https://ai-med.jp/hospitals"
     schedule: "40 2 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://ai-med.jp/clause"
 
   - site_id: challenge_plus
     name: "チャレンジプラス"
@@ -407,7 +407,7 @@ sites:
     url: "https://www.challenge-plus.jp/list/"
     schedule: "40 2 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.challenge-plus.jp/ctsite/"
 
   - site_id: entre_net
     name: "アントレ"
@@ -415,7 +415,7 @@ sites:
     url: "https://entrenet.jp/dokuritsu/?cbn=top_src_fw"
     schedule: "40 2 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://entrenet.jp/others/kiyaku/"
 
   - site_id: gappori
     name: "ガッポリ"
@@ -423,7 +423,7 @@ sites:
     url: "https://gappori.jp/a_search/w_/"
     schedule: "40 2 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://gappori.jp/a_site_rule/"
 
   - site_id: hanacupid
     name: "花キューピット"
@@ -431,7 +431,7 @@ sites:
     url: "https://www.hanacupid.or.jp/stores/"
     schedule: "40 2 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.i879.com/about/"
 
   - site_id: dan_work
     name: "男ワーク"
@@ -439,7 +439,7 @@ sites:
     url: "https://www.dan-work.com"
     schedule: "40 2 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: hamanight
     name: "ハマんナイト"
@@ -447,7 +447,7 @@ sites:
     url: "http://www.hamanight.com"
     schedule: "0 3 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "http://www.hamanight.com/tos.html"
 
   - site_id: tainew_otoko
     name: "メンズ体入"
@@ -455,7 +455,7 @@ sites:
     url: "https://tainew-otoko.com/shoplist/search/?salary_type=0_1&word="
     schedule: "0 3 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tainew-otoko.com/menu/terms/"
 
   - site_id: epark_dental
     name: "EPARK歯科"
@@ -463,7 +463,7 @@ sites:
     url: "https://haisha-yoyaku.jp/bun2sdental/list/"
     schedule: "0 3 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://haisha-yoyaku.jp/terms.html"
 
   - site_id: jobcon_driver
     name: "ジョブコンプラスD"
@@ -471,7 +471,7 @@ sites:
     url: "https://job-con.jp/driver/search"
     schedule: "0 3 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://job-con.jp/policy"
 
   - site_id: jobcon_security
     name: "ジョブコンプラスS"
@@ -479,7 +479,7 @@ sites:
     url: "https://job-con.jp/security/search"
     schedule: "0 3 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://job-con.jp/policy"
 
   - site_id: job_chocolat
     name: "ジョブショコラ"
@@ -487,7 +487,7 @@ sites:
     url: "https://job-chocolat.jp/"
     schedule: "0 3 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://job-chocolat.jp/terms/"
 
   - site_id: doraever
     name: "ドラEVER"
@@ -495,7 +495,7 @@ sites:
     url: "https://doraever.jp/job-lists/1"
     schedule: "0 3 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://doraever.jp/terms"
 
   - site_id: jwarm
     name: "ジェイウォーム"
@@ -503,7 +503,7 @@ sites:
     url: "https://www.jwarm.net/uni_items.php?pg=1&ig=i"
     schedule: "0 3 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jwarm.net/rule.html"
 
   - site_id: kyujin_journal_net
     name: "求人ジャーナルネット"
@@ -511,7 +511,7 @@ sites:
     url: "https://www.job-j.net"
     schedule: "20 3 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.job-j.net/static/rules/"
 
   - site_id: baitoru
     name: "バイトル"
@@ -519,7 +519,7 @@ sites:
     url: "https://baitoru.com/search/list/"
     schedule: "10 18 * * TUE"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.baitoru.com/about/kiyaku_base.html"
 
   - site_id: townwork
     name: "タウンワーク"
@@ -527,7 +527,7 @@ sites:
     url: "https://townwork.net/"
     schedule: "20 3 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/twn-t-1005/index.html"
 
   - site_id: rikunabi_next_syataku
     name: "リクナビNEXT社宅"
@@ -535,7 +535,7 @@ sites:
     url: "https://next.rikunabi.com/job_search/kw/%E7%A4%BE%E5%AE%85/"
     schedule: "20 3 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/rnn-t-1001/index.html"
 
   - site_id: rikunabi_next_syayosha
     name: "リクナビNEXT社用車"
@@ -543,7 +543,7 @@ sites:
     url: "https://next.rikunabi.com/job_search/kw/%E7%A4%BE%E7%94%A8%E8%BB%8A%E5%88%B6%E5%BA%A6/"
     schedule: "20 3 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/rnn-t-1001/index.html"
 
   - site_id: caloo
     name: "Caloo病院検索"
@@ -551,7 +551,7 @@ sites:
     url: "https://caloo.jp/hospitals/search/01/all"
     schedule: "20 3 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://caloo.jp/terms/"
 
   - site_id: gaten_job
     name: "ガテン系仕事ナビ"
@@ -559,7 +559,7 @@ sites:
     url: "https://gaten-job.com/sitemap.xml"
     schedule: "20 3 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://gaten-job.com/immunity"
 
   - site_id: jobpost
     name: "ジョブポスト"
@@ -567,7 +567,7 @@ sites:
     url: "https://jobpost.jp/search/g:1/"
     schedule: "20 3 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://jobpost.jp/terms"
 
   - site_id: trck_job
     name: "トラッカーズジョブ"
@@ -575,7 +575,7 @@ sites:
     url: "https://job.trck.jp/sitemap.xml"
     schedule: "40 3 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://azoop.co.jp/privacy_policy"
 
   - site_id: barberin
     name: "バーバリン"
@@ -583,7 +583,7 @@ sites:
     url: "https://barberin.jp/"
     schedule: "40 3 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://barberin.jp/condition/"
 
   - site_id: fc_kamei
     name: "フランチャイズ加盟募集"
@@ -591,7 +591,7 @@ sites:
     url: "https://fc-kamei.net"
     schedule: "40 3 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://fc-kamei.net/terms"
 
   - site_id: benrishi_navi
     name: "弁理士ナビ"
@@ -599,7 +599,7 @@ sites:
     url: "https://www.benrishi-navi.com"
     schedule: "40 3 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: prtimes
     name: "PRTIMES"
@@ -607,7 +607,7 @@ sites:
     url: "https://prtimes.jp/technology/"
     schedule: "40 3 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://prtimes.jp/main/html/kiyaku"
 
   - site_id: kessan_kokoku
     name: "決算公告（catr.jp）"
@@ -615,7 +615,7 @@ sites:
     url: "https://catr.jp/cities/0"
     schedule: "40 3 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://catr.jp/about"
 
   - site_id: host_para
     name: "ホスパラ"
@@ -623,7 +623,7 @@ sites:
     url: "https://host-paradise.jp/"
     schedule: "40 3 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://host-paradise.jp/policy/"
 
   - site_id: mynavi_tenshoku
     name: "マイナビ転職"
@@ -631,7 +631,7 @@ sites:
     url: "https://tenshoku.mynavi.jp/list/pg1/"
     schedule: "40 3 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tenshoku.mynavi.jp/rules/member/"
 
   - site_id: en_tenshoku
     name: "エン転職"
@@ -639,7 +639,7 @@ sites:
     url: "https://employment.en-japan.com/k_tokyo/"
     schedule: "0 4 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://employment.en-japan.com/info/membership/"
 
   - site_id: kyujin_box_tokutei
     name: "求人ボックス（特定技能の仕事）"
@@ -647,7 +647,7 @@ sites:
     url: "https://xn--pckua2a7gp15o89zb.com/%E7%89%B9%E5%AE%9A%E6%8A%80%E8%83%BD%E3%81%AE%E4%BB%95%E4%BA%8B"
     schedule: "0 4 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
   - site_id: kkhashi
     name: "カケハシ"
@@ -655,7 +655,7 @@ sites:
     url: "https://www.kkhashi.com/matters?ref=%E5%85%A8%E3%81%A6%E3%81%AE%E6%A1%88%E4%BB%B6%E3%81%8B%E3%82%89%E6%8E%A2%E3%81%99"
     schedule: "0 4 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.kakehashi.life/support-site-terms"
 
   - site_id: bahn_rep
     name: "バーン代理店"
@@ -663,7 +663,7 @@ sites:
     url: "https://bahn-rep.com/category/allarea/page/1"
     schedule: "0 7 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://phst.jp/burn_studio/front/page/index.html?page_type=rule&page_path=index"
 
   - site_id: kyujinbox
     name: "求人ボックス（携帯販売・通信系）"
@@ -671,7 +671,7 @@ sites:
     url: "https://xn--pckua2a7gp15o89zb.com/"
     schedule: "0 4 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
   - site_id: b_seeds
     name: "Bシーズ"
@@ -679,7 +679,7 @@ sites:
     url: "https://b-seeds.com/news/"
     schedule: "0 4 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://b-seeds.com/kiyaku/"
 
   - site_id: mlit_kensetsu
     name: "国交省建設業者検索_建設業"
@@ -687,7 +687,7 @@ sites:
     url: "https://etsuran2.mlit.go.jp/TAKKEN/kensetuKensaku.do?outPutKbn=1"
     schedule: "0 4 8-14 * SAT"
     enabled: true    
-    terms_url: ""
+    terms_url: "https://www.digital.go.jp/resources/open_data/public_data_license_v1.0"
 
   - site_id: mlit_takken
     name: "建設業者・宅建業者等企業情報検索システム【賃貸住宅管理業者】"
@@ -695,7 +695,7 @@ sites:
     url: "https://etsuran2.mlit.go.jp/TAKKEN/takkenKensaku.do"
     schedule: "0 4 8-14 * SAT"
     enabled: true   
-    terms_url: ""
+    terms_url: "https://www.digital.go.jp/resources/open_data/public_data_license_v1.0"
 
   - site_id: aupay
     name: "aupay"
@@ -703,7 +703,7 @@ sites:
     url: "https://aupay.auone.jp/"
     schedule: "0 6 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://wallet.auone.jp/contents/lp/terms/aupayall.html"
 
   - site_id: tabelog
     name: "食べログ"
@@ -711,7 +711,7 @@ sites:
     url: "https://tabelog.com/"
     schedule: "0 6 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tabelog.com/help/rules/"
 
   - site_id: foodslabo
     name: "foodslabo"
@@ -719,7 +719,7 @@ sites:
     url: "https://foods-labo.com/"
     schedule: "0 6 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://foods-labo.com/terms"
 
   - site_id: ivry
     name: "ivry"
@@ -727,7 +727,7 @@ sites:
     url: "https://ivry.jp/"
     schedule: "0 7 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://ivry.jp/terms/"
 
   - site_id: kocchake
     name: "kocchake"
@@ -735,7 +735,7 @@ sites:
     url: "https://kocchake.com/"
     schedule: "40 6 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://kocchake.com/pages/privacy-policy"
 
   - site_id: rakuten_beauty_2
     name: "rakuten_beauty"
@@ -743,7 +743,7 @@ sites:
     url: "https://beauty.rakuten.co.jp/"
     schedule: "0 6 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://beauty.rakuten.co.jp/cnt/terms/"
 
   - site_id: savor_japan
     name: "savor_japan"
@@ -751,7 +751,7 @@ sites:
     url: "https://savorjapan.com/"
     schedule: "20 6 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://savorjapan.com/terms"
 
   - site_id: emily_job
     name: "体入エミリー"
@@ -759,7 +759,7 @@ sites:
     url: "https://emily-job.jp/"
     schedule: "0 6 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://emily-job.jp/policy/"
 
   - site_id: suumo_2
     name: "suumo【不動産会社ガイド】"
@@ -767,7 +767,7 @@ sites:
     url: "https://suumo.jp/fudousankaisha/"
     schedule: "40 6 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/suu-t-1003/index.html"
 
   - site_id: agri_navi
     name: "あぐりナビ"
@@ -775,7 +775,7 @@ sites:
     url: "https://www.agri-navi.com/"
     schedule: "20 6 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.agri-navi.com/membership_agreement"
 
   - site_id: o_kuruma
     name: "おくるまドットコム"
@@ -783,7 +783,7 @@ sites:
     url: "https://www.o-kuruma.com/"
     schedule: "20 6 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.o-kuruma.com/html/policy.html"
 
   - site_id: curama
     name: "くらしのマーケット"
@@ -791,7 +791,7 @@ sites:
     url: "https://curama.jp/"
     schedule: "0 7 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://curama.jp/terms/"
 
   - site_id: gnavi
     name: "ぐるなび"
@@ -799,7 +799,7 @@ sites:
     url: "https://www.gnavi.co.jp/"
     schedule: "20 6 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://corporate.gnavi.co.jp/agreement/"
 
   - site_id: mypl
     name: "まいぷれ"
@@ -807,7 +807,7 @@ sites:
     url: "https://mypl.net/"
     schedule: "0 7 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://mypl.net/use_policy/"
 
   - site_id: moe_navi
     name: "もえなび"
@@ -815,7 +815,7 @@ sites:
     url: "https://www.moe-navi.jp/"
     schedule: "40 6 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://moe-life.jp/rules/"
 
   - site_id: ai_med_2
     name: "アイメッド"
@@ -831,7 +831,7 @@ sites:
     url: "https://www.asoview.com/base/"
     schedule: "40 6 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.asoview.com/info/terms/"
 
   - site_id: up_stage
     name: "アップステージ"
@@ -839,7 +839,7 @@ sites:
     url: "https://www.up-stage.info/"
     schedule: "40 6 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.up-stage.info/contents-regulation/"
 
   - site_id: baito
     name: "アルバイトナイツ"
@@ -847,7 +847,7 @@ sites:
     url: "https://baito.nights.fun/"
     schedule: "40 6 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://baito.nights.fun/help/rules/"
 
   - site_id: mono
     name: "イプロス"
@@ -855,7 +855,7 @@ sites:
     url: "https://mono.ipros.com/"
     schedule: "20 7 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://my.ipros.com/legal/"
 
   - site_id: carcon
     name: "カーコンビニ俱楽部"
@@ -863,7 +863,7 @@ sites:
     url: "https://www.carcon.co.jp/"
     schedule: "40 7 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.carcon.co.jp/privacy/"
 
   - site_id: carsensor
     name: "カーセンサー"
@@ -871,7 +871,7 @@ sites:
     url: "https://www.carsensor.net/"
     schedule: "20 6 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/car-t-1008/index.html"
 
   - site_id: cabaito
     name: "キャバイト求人"
@@ -879,7 +879,7 @@ sites:
     url: "https://www.cabaito.jp/"
     schedule: "20 6 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.cabaito.jp/rule.html"
 
   - site_id: genbars
     name: "ゲンバーズ"
@@ -887,7 +887,7 @@ sites:
     url: "https://genbars.jp/"
     schedule: "0 7 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://genbars.jp/contents-regulation/"
 
   - site_id: webjobpark
     name: "ジョブこねっと"
@@ -895,7 +895,7 @@ sites:
     url: "https://webjobpark.kyoto.jp/"
     schedule: "0 7 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://webjobpark.kyoto.jp/rules/"
 
   - site_id: job_chocolat_2
     name: "ジョブショコラ"
@@ -903,7 +903,7 @@ sites:
     url: "https://job-chocolat.jp/"
     schedule: "20 7 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://job-chocolat.jp/terms/"
 
   - site_id: navi
     name: "ジョブナビ愛知"
@@ -911,7 +911,7 @@ sites:
     url: "https://www.navi.j-kin.com/"
     schedule: "0 6 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.navi.j-kin.com/index.php?app_controller=page&p=membership"
 
   - site_id: concierge
     name: "ダイエットコンシェルジュ"
@@ -919,7 +919,7 @@ sites:
     url: "https://concierge.diet/"
     schedule: "0 6 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://concierge.diet/service/"
 
   - site_id: moppy_baito
     name: "ディスカバイト"
@@ -927,7 +927,7 @@ sites:
     url: "https://moppy-baito.com/"
     schedule: "40 7 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://moppy-baito.com/kiyaku/"
 
   - site_id: trimtrim_salons
     name: "トリムトリム【サロン】"
@@ -935,7 +935,7 @@ sites:
     url: "https://trimtrim.jp/salons"
     schedule: "20 6 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://trimtrim.jp/tos"
 
   - site_id: trimtrim_hotels
     name: "トリムトリム【ホテル】"
@@ -943,7 +943,7 @@ sites:
     url: "https://trimtrim.jp/hotels"
     schedule: "20 6 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://trimtrim.jp/tos"
 
   - site_id: nuri_kae
     name: "ヌリカエ"
@@ -951,7 +951,7 @@ sites:
     url: "https://www.nuri-kae.jp/"
     schedule: "40 6 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.nuri-kae.jp/rule"
 
   - site_id: hellowork
     name: "ハローワーク"
@@ -959,7 +959,7 @@ sites:
     url: "https://www.hellowork.mhlw.go.jp/"
     schedule: "0 6 * * SUN"  # 失敗することがあるらしいので、一旦週一実行に変更
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.hellowork.mhlw.go.jp/info/terms.html"
 
   - site_id: hellowork_shinnkikyuujin
     name: "ハローワーク（新規求人）"
@@ -967,7 +967,7 @@ sites:
     url: "https://www.hellowork.mhlw.go.jp/"
     schedule: "0 1 2-31/3 * *"  # 3日おき 午前1時 (全件クロールの2時間前)
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.hellowork.mhlw.go.jp/info/terms.html"
 
   - site_id: baitona_joshi
     name: "バイトな女子"
@@ -975,7 +975,7 @@ sites:
     url: "https://baitona-joshi.jp/"
     schedule: "40 6 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://baitona-joshi.jp/terms/"
 
   - site_id: com
     name: "バーバーナビ.com"
@@ -983,7 +983,7 @@ sites:
     url: "https://barbernavi.com/"
     schedule: "0 7 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://barbernavi.com/privacy-policy/"
 
   - site_id: doda
     name: "doda"
@@ -991,7 +991,7 @@ sites:
     url: "https://doda.jp/DodaFront/View/JobSearchList.action"
     schedule: "20 4 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://doda.jp/material/kiyaku/001.html"
 
   - site_id: mynavi2027
     name: "マイナビ2027"
@@ -999,7 +999,7 @@ sites:
     url: "https://job.mynavi.jp/2027/"
     schedule: "20 4 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://job.mynavi.jp/sitepolicy/index.html"
 
   - site_id: baitoru_next
     name: "バイトルNEXT"
@@ -1007,7 +1007,7 @@ sites:
     url: "https://www.baitoru.com/tohoku/jlist/shain/"
     schedule: "40 4 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.baitoru.com/about/kiyaku.html"
 
   - site_id: biz_all
     name: "比較ビズ（全業種）"
@@ -1015,7 +1015,7 @@ sites:
     url: "https://www.biz.ne.jp/"
     schedule: "0 5 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.biz.ne.jp/help/regulation.html"
 
   - site_id: activityjapan
     name: "アクティビティジャパン"
@@ -1023,7 +1023,7 @@ sites:
     url: "https://activityjapan.com/publish/feature"
     schedule: "0 5 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://activityjapan.com/accept/use/policy"
 
   - site_id: qlife
     name: "QLife"
@@ -1031,7 +1031,7 @@ sites:
     url: "https://www.qlife.co.jp/"
     schedule: "20 5 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.qlife.co.jp/terms"
 
   - site_id: kurashinomarket
     name: "くらしのマーケット（カテゴリ）"
@@ -1039,7 +1039,7 @@ sites:
     url: "https://curama.jp/category/"
     schedule: "20 5 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://curama.jp/terms/"
 
   - site_id: kaago
     name: "Kaago"
@@ -1047,7 +1047,7 @@ sites:
     url: "https://kaago.com/"
     schedule: "40 5 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://kaago.com/static/tos/"
 
   - site_id: lixil_reformshop
     name: "LIXILリフォームショップ"
@@ -1055,7 +1055,7 @@ sites:
     url: "https://www.lixil-reformshop.jp/"
     schedule: "40 5 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.lixil-reformshop.jp/termsofuse/"
 
   - site_id: ozmall_hairsalon
     name: "オズモール（ヘアサロン）"
@@ -1063,7 +1063,7 @@ sites:
     url: "https://www.ozmall.co.jp/hairsalon"
     schedule: "0 6 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ozmall.co.jp/introduction/14118/"
 
   - site_id: pola
     name: "POLA"
@@ -1071,7 +1071,7 @@ sites:
     url: "https://www.pola.co.jp/"
     schedule: "0 6 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.pola.co.jp/privacy/rule/"
 
   - site_id: cookbiz
     name: "クックビズ"
@@ -1079,7 +1079,7 @@ sites:
     url: "https://cookbiz.co.jp/companies"
     schedule: "0 4 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cookbiz.co.jp/terms"
 
   - site_id: rejob
     name: "Rejob"
@@ -1087,7 +1087,7 @@ sites:
     url: "https://rejob.co.jp/"
     schedule: "20 4 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://relax-job.com/info/terms"
 
   - site_id: domonet
     name: "ドモネット"
@@ -1095,7 +1095,7 @@ sites:
     url: "https://domonet.jp/"
     schedule: "40 4 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://domonet.jp/info/agreement"
 
   - site_id: anny
     name: "Anny"
@@ -1103,7 +1103,7 @@ sites:
     url: "https://oiwai.anny.gift/search?numPpl=2"
     schedule: "40 4 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://oiwai.anny.gift/terms-of-use"
 
   - site_id: cafe397
     name: "Cafe397"
@@ -1111,7 +1111,7 @@ sites:
     url: "https://397.cafe/search.php?mode=&page=1"
     schedule: "0 5 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://397.cafe/page.php?page=rule"
 
   - site_id: japan_food_guide
     name: "Japan Food Guide"
@@ -1119,7 +1119,7 @@ sites:
     url: "https://japan-food.guide/"
     schedule: "0 5 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://japan-food.guide/terms_of_use"
 
   - site_id: ozmall_restaurant
     name: "オズモール（レストラン）"
@@ -1127,7 +1127,7 @@ sites:
     url: "https://www.ozmall.co.jp/restaurant/list/"
     schedule: "20 5 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ozmall.co.jp/introduction/14118/"
 
   - site_id: beautypark
     name: "Beauty Park"
@@ -1135,7 +1135,7 @@ sites:
     url: "https://www.beauty-park.jp/"
     schedule: "20 5 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.beauty-park.jp/pages/use_rule/"
 
   - site_id: hospita
     name: "HOSPITA"
@@ -1143,7 +1143,7 @@ sites:
     url: "https://www.hospita.jp/list/hospital/"
     schedule: "40 5 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.hospita.jp/about/terms-of-use"
 
   - site_id: caferun
     name: "カフェるん"
@@ -1151,7 +1151,7 @@ sites:
     url: "https://caferun.jp/"
     schedule: "40 5 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://caferun.jp/terms/"
 
   - site_id: dartslive
     name: "DARTSLIVE"
@@ -1159,7 +1159,7 @@ sites:
     url: "https://search.dartslive.com/jp/shops/"
     schedule: "0 6 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.dartslive.com/jp/terms/"
 
   - site_id: fitmap
     name: "Fit Map"
@@ -1167,7 +1167,7 @@ sites:
     url: "https://fitmap.jp/"
     schedule: "0 4 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://fitmap.jp/agree/"
 
   - site_id: imitsu_pr
     name: "PRONIアイミツ_PR"
@@ -1175,7 +1175,7 @@ sites:
     url: "https://imitsu.jp/ct-pr/search/"
     schedule: "0 4 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://imitsu.jp/terms/"
 
   - site_id: pepperlikes
     name: "PepperLikes"
@@ -1183,7 +1183,7 @@ sites:
     url: "https://www.pepperlikes.com/"
     schedule: "20 4 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.pepperlikes.com/terms-and-conditions"
 
   - site_id: manabi_senmon
     name: "マナビ（専門）"
@@ -1191,7 +1191,7 @@ sites:
     url: "https://manabi.benesse.ne.jp/senmon"
     schedule: "20 4 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://manabi.benesse.ne.jp/doc/rules/rules.html"
 
   - site_id: biztel
     name: "BIZTEL"
@@ -1199,7 +1199,7 @@ sites:
     url: "https://biztel.jp/"
     schedule: "40 4 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://biztel.jp/agreement/"
 
   - site_id: domo
     name: "Domo"
@@ -1207,7 +1207,7 @@ sites:
     url: "https://www.domo.com/jp/customers"
     schedule: "40 4 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.domo.com/jp/company/service-terms"
 
   - site_id: hnavi
     name: "発注ナビ"
@@ -1215,7 +1215,7 @@ sites:
     url: "https://hnavi.co.jp/corporation/"
     schedule: "0 5 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://hnavi.co.jp/tos/"
 
   - site_id: j_lic
     name: "J-LIC"
@@ -1223,7 +1223,7 @@ sites:
     url: "https://j-lic.com/"
     schedule: "0 5 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://j-lic.com/terms"
 
   - site_id: kepple
     name: "KEPPLE"
@@ -1231,7 +1231,7 @@ sites:
     url: "https://kepple.co.jp/articles/page/1"
     schedule: "0 4 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://kepple.co.jp/term"
 
   - site_id: kyozon
     name: "kyozon"
@@ -1239,7 +1239,7 @@ sites:
     url: "https://kyozon.net/service-list/"
     schedule: "20 5 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://kyozon.net/company/terms-of-use/"
 
   - site_id: pitta_lab
     name: "ピッタラボ"
@@ -1247,7 +1247,7 @@ sites:
     url: "https://pitta-lab.com/"
     schedule: "20 5 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://pitta-lab.com/termsOfUse"
 
   - site_id: nihon_souko_kyokai
     name: "日本倉庫協会"
@@ -1255,7 +1255,7 @@ sites:
     url: "https://www.nissokyo.or.jp/member_list/"
     schedule: "0 6 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.nissokyo.or.jp/privacypolicy/"
 
   - site_id: nihon_reizousouko_kyokai
     name: "日本冷蔵倉庫協会"
@@ -1263,7 +1263,7 @@ sites:
     url: "https://www.jarw.or.jp/find/memberlist/"
     schedule: "0 8 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jarw.or.jp/privacy"
 
   - site_id: j_reit
     name: "J-REIT"
@@ -1271,7 +1271,7 @@ sites:
     url: "https://j-reit.jp/brand/"
     schedule: "0 2 * * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://j-reit.jp/notice.html"
 
   - site_id: dairitenhonpo
     name: "代理店募集本舗"
@@ -1279,7 +1279,7 @@ sites:
     url: "https://dairitenboshu.com/search/"
     schedule: "40 5 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://dairitenboshu.com/pages/terms"
 
   - site_id: panasonic_cycle
     name: "Panasonic Cycle"
@@ -1287,7 +1287,7 @@ sites:
     url: "https://cycle.panasonic.com/"
     schedule: "40 5 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://holdings.panasonic/jp/terms-of-use.html"
 
   - site_id: sumitec_kanto
     name: "住まいテック関東"
@@ -1295,7 +1295,7 @@ sites:
     url: "https://sumitec-kanto.com/contractor"
     schedule: "0 4 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://sumitec-kanto.com/term/"
 
   - site_id: hiroshima_hitec
     name: "広島市ハイテクプラザ"
@@ -1303,7 +1303,7 @@ sites:
     url: "https://www.hitec.city.hiroshima.jp/"
     schedule: "0 4 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.itc.city.hiroshima.jp/privacy.html"
 
   - site_id: sanpai_kun
     name: "さんぱいくん"
@@ -1311,7 +1311,7 @@ sites:
     url: "https://www2.sanpainet.or.jp/zyohou"
     schedule: "20 4 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.sanpainet.or.jp/content.php?id=2"
 
   - site_id: alzo
     name: "アルゾ"
@@ -1319,7 +1319,7 @@ sites:
     url: "https://www.alzoweb.jp/search"
     schedule: "20 4 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.alzoweb.jp/?act=kiyaku"
 
   - site_id: anokono_ehime
     name: "あの子のエヒメ"
@@ -1327,7 +1327,7 @@ sites:
     url: "https://ano-kono.ehime.jp/search"
     schedule: "40 4 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://ano-kono.ehime.jp/st/terms/"
 
   - site_id: bejob_navi
     name: "BEJOBナビ"
@@ -1335,7 +1335,7 @@ sites:
     url: "https://www.bejob-navi.jp/"
     schedule: "40 4 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.bejob-navi.jp/contract.php"
 
   - site_id: ishikawa_jobnavi
     name: "石川ジョブナビ"
@@ -1343,7 +1343,7 @@ sites:
     url: "https://jobnavi-i.jp/"
     schedule: "0 5 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://jobnavi-i.jp/terms/"
 
   - site_id: jinzai_hellowork_syokugyo_syoukai
     name: "人材サービス総合【職業紹介】"
@@ -1351,7 +1351,7 @@ sites:
     url: "https://jinzai.hellowork.mhlw.go.jp/JinzaiWeb"
     schedule: "0 5 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://jinzai.hellowork.mhlw.go.jp/icb_data/StaticContents/GICB190020.html"
 
   - site_id: kyujin_box_ginoujissyuu
     name: "求人ボックス（技能実習の仕事）"
@@ -1359,7 +1359,7 @@ sites:
     url: "https://xn--pckua2a7gp15o89zb.com/%E6%8A%80%E8%83%BD%E5%AE%9F%E7%BF%92%E3%81%AE%E4%BB%95%E4%BA%8B"
     schedule: "20 5 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
   - site_id: vinty
     name: "VINTY"
@@ -1367,7 +1367,7 @@ sites:
     url: "https://www.vinty.jp/search"
     schedule: "20 5 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.vinty.jp/terms"
 
   - site_id: guppy
     name: "GUPPY"
@@ -1375,7 +1375,7 @@ sites:
     url: "https://www.guppy.jp/"
     schedule: "0 6 * * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.guppy.jp/terms"
 
   - site_id: hikariweb_search
     name: "ひかりWeb NTT東日本特約店・販売委託店"
@@ -1383,7 +1383,7 @@ sites:
     url: "https://hikariweb.ntt-east.co.jp/general/search/list.php?keyword=1"
     schedule: "20 5 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: hikariweb_cancell
     name: "ひかりWeb NTT東日本解約特約店・販売委託店"
@@ -1391,7 +1391,7 @@ sites:
     url: "https://hikariweb.ntt-east.co.jp/general/cancell/list.php?keyword=1"
     schedule: "20 5 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: nightstyle
     name: "ナイトスタイル"
@@ -1399,7 +1399,7 @@ sites:
     url: "https://nightstyle.jp"
     schedule: "40 7 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://nightstyle.jp/terms/"
 
   - site_id: baitoru_nightwork
     name: "バイトル（ナイトワーク系）"
@@ -1407,7 +1407,7 @@ sites:
     url: "https://www.baitoru.com/lp/jobcategory/"
     schedule: "30 4 * * MON"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.baitoru.com/about/kiyaku_base.html"
 
   - site_id: epark_hotel
     name: "EPARKホテル・宿泊"
@@ -1415,7 +1415,7 @@ sites:
     url: "https://epark.jp/hotel-stay/list/"
     schedule: "0 7 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://terms.epark.jp/use/"
 
   - site_id: dummy
     name: "ダミー"
@@ -1431,7 +1431,7 @@ sites:
     url: "https://hostle.jp"
     schedule: "40 5 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://hostle.jp/guide/"
 
   - site_id: ntt_west_hanbaiten
     name: "NTT西日本特約店・販売委託店一覧"
@@ -1439,7 +1439,7 @@ sites:
     url: "https://www2.hanbaiten.cpe.isp.ntt-west.co.jp/lists"
     schedule: "0 3 1-7 * MON"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ntt-west.co.jp/share/privacy.html"
 
   - site_id: jinzai_service
     name: "人材サービス総合サイト（職業紹介事業）"
@@ -1447,7 +1447,7 @@ sites:
     url: "https://jinzai.hellowork.mhlw.go.jp/JinzaiWeb/GICB101010.do?action=initDisp&screenId=GICB101010"
     schedule: "0 8 * * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://jinzai.hellowork.mhlw.go.jp/JinzaiWeb/"
 
   - site_id: casmoo
     name: "ウィリスト"
@@ -1455,7 +1455,7 @@ sites:
     url: "https://casmoo.jp/"
     schedule: "0 1 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://casmoo.jp/rule/"
 
   - site_id: bizresearch
     name: "ビズリサーチ"
@@ -1463,7 +1463,7 @@ sites:
     url: "https://bizresearch.net/"
     schedule: "0 3 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.bizreach.jp/pages/service/rules/"
 
   - site_id: tokyo_bm_recruit
     name: "ビルメン"
@@ -1471,7 +1471,7 @@ sites:
     url: "https://www.tokyo-bm-recruit.jp/"
     schedule: "0 5 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.j-bma.or.jp/site-policy/"
 
   - site_id: housing_bazar
     name: "ハウジングバザール"
@@ -1479,7 +1479,7 @@ sites:
     url: "https://www.housingbazar.jp/vendors/search.php?p[]="
     schedule: "0 7 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.housingbazar.jp/tou/"
 
   - site_id: girlsbaito
     name: "ガールズバイト"
@@ -1487,7 +1487,7 @@ sites:
     url: "https://girlsbaito.jp/kanto"
     schedule: "30 3 15-21 * 6"
     enabled: true
-    terms_url: ""
+    terms_url: "https://girlsbaito.jp/kanto/agreement"
 
   - site_id: gb-walker
     name: "ガールズバーウォーカー"
@@ -1495,7 +1495,7 @@ sites:
     url: "https://www.gb-walker.jp/"
     schedule: "30 5 15-21 * 6"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.gb-walker.jp/guideline/"
 
   - site_id: lounge-tapioka
     name: "ラウンジタピオカガールズバー"
@@ -1503,7 +1503,7 @@ sites:
     url: "https://lounge-tapioca.com/"
     schedule: "30 4 15-21 * 6"
     enabled: true
-    terms_url: ""
+    terms_url: "https://lounge-tapioca.com/policy/"
 
   - site_id: hoskyu
     name: "ホスト求人ドットコム"
@@ -1511,7 +1511,7 @@ sites:
     url: "https://www.hoskyu.com/"
     schedule: "30 1 15-21 * 6"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: iiyeah_tateru
     name: "iiYEAH!を建てる"
@@ -1519,14 +1519,14 @@ sites:
     url: "https://iiyeah-tateru.jp/shops"
     schedule: "0 9 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://iiyeah-tateru.jp/terms"
 
   - site_id: philippine_pub
     name: "フィリピンパブどっと混む"
     module: "nightlife.philippine_pub"
     url: "https://philippine-pub.com/"
     schedule: "30 4 8-14 * SUN"
-    terms_url: ""
+    terms_url: "https://philippine-pub.com/terms/"
 
   - site_id: girlsmeee
     name: "体入ガールズミー"
@@ -1534,7 +1534,7 @@ sites:
     url: "https://girlsmeee.com"
     schedule: "30 5 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://girlsmeee.com/policy/terms-of-use"
 
   - site_id: snack_navi
     name: "スナックナビ"
@@ -1542,7 +1542,7 @@ sites:
     url: "https://snacknavi.com/girl_top.php?page=1"
     schedule: "30 6 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://snacknavi.com/privacy.php"
 
   - site_id: pachi_town
     name: "DMMぱちタウン"
@@ -1550,7 +1550,7 @@ sites:
     url: "https://p-town.dmm.com/shops/tokyo"
     schedule: "0 11 * * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://p-town.dmm.com/terms"
 
   - site_id: arubaito_ex
     name: "アルバイトEX"
@@ -1558,7 +1558,7 @@ sites:
     url: "https://arubaito-ex.jp/search?form_type=header_search"
     schedule: "30 4 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://arubaito-ex.jp/terms"
 
   - site_id: gaten_info
     name: "ガテン職"
@@ -1566,7 +1566,7 @@ sites:
     url: "https://gaten.info/"
     schedule: "0 3 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://gaten.info/apply-terms"
 
   - site_id: shokuba_mhlw_import
     name: "しょくばらぼ公式CSV差分"
@@ -1574,7 +1574,7 @@ sites:
     url: "https://shokuba.mhlw.go.jp/shokuba/utilize/download010?lang=JA"
     schedule: "0 11 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://shokuba.mhlw.go.jp/080/010/20180302211203.html"
 
   - site_id: tattoo_navi
     name: "タットゥースタジオナビ"
@@ -1582,7 +1582,7 @@ sites:
     url: "https://tattoo-navi.jp/studio/"
     schedule: "0 3 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tattoo-navi.jp/terms/"
 
   - site_id: onsen_kyokai
     name: "日本温泉協会"
@@ -1590,7 +1590,7 @@ sites:
     url: "https://www.spa.or.jp/search_p/"
     schedule: "0 1 * * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: cabacrown
     name: "キャバクラウン"
@@ -1598,7 +1598,7 @@ sites:
     url: "https://cabacrown.net/kw/all/all/"
     schedule: "0 2 18 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cabacrown.net/contents-regulation/"
 
   - site_id: tsukulink
     name: "ツクリンク"
@@ -1606,7 +1606,7 @@ sites:
     url: "https://tsukulink.net"
     schedule: "0 2 19 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tsukulink.net/term"
 
   - site_id: naisuta
     name: "ナイスタ"
@@ -1614,7 +1614,7 @@ sites:
     url: "https://naisuta.com/search/honnyu/"
     schedule: "0 2 19 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://naisuta.com/terms/"
 
   - site_id: nights_fun
     name: "ナイツネット"
@@ -1622,7 +1622,7 @@ sites:
     url: "https://www.nights.fun/04-sitemap-shop-list.xml"
     schedule: "30 4 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.nights.fun/aichi/membership/"
 
   - site_id: caba2
     name: "キャバキャバ"
@@ -1630,7 +1630,7 @@ sites:
     url: "https://www.caba2.net/bar_sitemap.xml"
     schedule: "30 4 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.caba2.net/term"
 
   - site_id: yorunabi
     name: "ヨルナビ"
@@ -1638,7 +1638,7 @@ sites:
     url: "https://yorumachi.jp/sitemap.xml"
     schedule: "30 5 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://yorumachi.jp/company.html"
 
   - site_id: pokepara_tainew
     name: "ポケパラ体入"
@@ -1646,7 +1646,7 @@ sites:
     url: "https://www.pokepara-tainew.jp/"
     schedule: "0 2 21 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://offer.pokepara-tainew.jp/other/member.html"
 
   - site_id: eiga_theater
     name: "映画.com 映画館情報"
@@ -1654,7 +1654,7 @@ sites:
     url: "https://eiga.com/theater/"
     schedule: "0 5 * * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://eiga.com/info/kiyaku/"
 
   - site_id: fitness_search
     name: "フィットネスサーチ"
@@ -1662,7 +1662,7 @@ sites:
     url: "https://www.fitness-search.net/"
     schedule: "0 9 * * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.fitness-search.net/html/terms.html"
 
   - site_id: sckanto
     name: "日本スイミングクラブ協会関東支部"
@@ -1670,7 +1670,7 @@ sites:
     url: "https://sckanto.net/"
     schedule: "0 3 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.sckanto.net/privacy/"
 
   - site_id: rakuten_travel
     name: "楽天トラベル 宿泊施設一覧"
@@ -1678,7 +1678,7 @@ sites:
     url: "https://travel.rakuten.co.jp/group/TIKU/"
     schedule: "0 0 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://travel.rakuten.co.jp/info/"
 
   - site_id: jalan
     name: "じゃらんnet 宿泊施設"
@@ -1686,7 +1686,7 @@ sites:
     url: "https://www.jalan.net/yado.html"
     schedule: "0 3 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/jln-t-1002/index.html"
 
   - site_id: type_2
     name: "女の転職type"
@@ -1694,7 +1694,7 @@ sites:
     url: "https://woman-type.jp/"
     schedule: "0 19 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://woman-type.jp/s/kojin/"
 
   - site_id: hoteltree_2
     name: "ホテルツリー"
@@ -1702,7 +1702,7 @@ sites:
     url: "https://hoteltree.jp"
     schedule: "0 0 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://hoteltree.jp/privacy-policy"
 
   - site_id: g_channel
     name: "G-CHANNEL"
@@ -1710,7 +1710,7 @@ sites:
     url: "https://www.g-channel.jp/"
     schedule: "0 20 9 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.g-channel.jp/terms/terms_pc.html"
 
   - site_id: daikumachi_2
     name: "水戸市大工町地区繁華街なび"
@@ -1718,7 +1718,7 @@ sites:
     url: "https://daikumachi.jp"
     schedule: "0 0 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://daikumachi.jp/privacy-policy"
 
   - site_id: takasaki_night_privity_fun
     name: "TAKASAKI NIGHT PRIVITY FUN"
@@ -1726,7 +1726,7 @@ sites:
     url: "https://www.takasaki-fun.jp/"
     schedule: "0 0 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: cute_p
     name: "求とぴ"
@@ -1734,7 +1734,7 @@ sites:
     url: "https://cute-p.info/"
     schedule: "0 0 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "http://cute-p.info/kiyaku"
 
   - site_id: hostgram
     name: "ホスタグラム"
@@ -1742,7 +1742,7 @@ sites:
     url: "https://hostgram.jp/"
     schedule: "0 0 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://hostgram.jp/terms"
 
   - site_id: meccel_night
     name: "めっけるナイト（栃木版）"
@@ -1750,7 +1750,7 @@ sites:
     url: "https://meccel.net/"
     schedule: "0 8 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: kaigo_kensaku
     name: "介護サービス情報公表システム"
@@ -1758,7 +1758,7 @@ sites:
     url: "https://www.kaigokensaku.mhlw.go.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.kaigokensaku.mhlw.go.jp/rule/"
 
   - site_id: green_japan
     name: "green_japan"
@@ -1766,7 +1766,7 @@ sites:
     url: "https://www.green-japan.com"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.green-japan.com/contents/terms"
 
   - site_id: ipros
     name: "ipros"
@@ -1774,7 +1774,7 @@ sites:
     url: "https://mono.ipros.com"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://my.ipros.com/legal/"
 
   - site_id: jarw
     name: "jarw"
@@ -1782,7 +1782,7 @@ sites:
     url: "https://www.jarw.or.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jarw.or.jp/privacy"
 
   - site_id: jdcc
     name: "jdcc"
@@ -1790,7 +1790,7 @@ sites:
     url: "https://www.jdcc.or.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jdcc.or.jp/policy/"
 
   - site_id: jta_jigyou
     name: "jta_jigyou"
@@ -1798,7 +1798,7 @@ sites:
     url: "https://jta.or.jp/association/link/jigyou.html"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jata-net.or.jp/site_policy/"
 
   - site_id: nissokyo
     name: "nissokyo"
@@ -1806,7 +1806,7 @@ sites:
     url: "https://www.nissokyo.or.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.nissokyo.or.jp/privacypolicy/"
 
   - site_id: nittenkyo
     name: "nittenkyo"
@@ -1814,7 +1814,7 @@ sites:
     url: "https://jexadb.nittenkyo.ne.jp/json/jexa_memb.tsv"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: web_kanji
     name: "web_kanji"
@@ -1822,7 +1822,7 @@ sites:
     url: "https://web-kanji.com"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://web-kanji.com/terms"
 
   - site_id: lister_work
     name: "lister_work"
@@ -1830,7 +1830,7 @@ sites:
     url: "https://www.lister.work"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.lister.work/terms_of_service/"
 
   - site_id: japan_golf_ngk
     name: "japan_golf_ngk"
@@ -1838,7 +1838,7 @@ sites:
     url: "https://www.golf-ngk.or.jp/course/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.golf-ngk.or.jp/privacy/index.html"
 
   - site_id: jinzai_hellowork
     name: "jinzai_hellowork"
@@ -1846,7 +1846,7 @@ sites:
     url: "https://jinzai.hellowork.mhlw.go.jp/JinzaiWeb/GICB101010.do?action=initDisp&screenId=GICB101010"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.hellowork.mhlw.go.jp/info/terms.html"
 
   - site_id: getswork
     name: "getswork"
@@ -1854,7 +1854,7 @@ sites:
     url: "https://www.getswork.com/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.getswork.com/terms.php"
 
   - site_id: GirlsBaito_scrape
     name: "GirlsBaito_scrape"
@@ -1862,7 +1862,7 @@ sites:
     url: "https://girlsbaito.jp/archive?search_mode=detail&page=1"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://girlsbaito.jp/kanto/agreement"
 
   - site_id: HostKyuzinDotcom_scrape
     name: "HostKyuzinDotcom_scrape"
@@ -1870,7 +1870,7 @@ sites:
     url: "https://www.hoskyu.com/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: oremichi
     name: "oremichi"
@@ -1878,7 +1878,7 @@ sites:
     url: "https://www.oremichi.com/sitemap/sitemap.shop.xml"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.oremichi.com/disclaimer/"
 
   - site_id: town_life_reform
     name: "town_life_reform"
@@ -1886,7 +1886,7 @@ sites:
     url: "https://www.town-life.jp/reform/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.town-life.jp/reform/terms.html"
 
   - site_id: works
     name: "works"
@@ -1894,7 +1894,7 @@ sites:
     url: "https://04510.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://04510.jp/policy/"
 
   - site_id: iko_yo
     name: "iko_yo"
@@ -1902,7 +1902,7 @@ sites:
     url: "https://iko-yo.net/facilities?genre_cluster=1"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://iko-yo.net/terms/service"
 
   - site_id: estelove_work
     name: "estelove_work"
@@ -1910,7 +1910,7 @@ sites:
     url: "https://job.eslove.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://job.eslove.jp/terms"
 
   - site_id: mens_job
     name: "mens_job"
@@ -1918,7 +1918,7 @@ sites:
     url: "https://mens-job.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://mens-job.jp/privacy_policy/"
 
   - site_id: nightly
     name: "nightly"
@@ -1926,7 +1926,7 @@ sites:
     url: "https://nightly.jp/job/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://nightly.jp/terms/"
 
   - site_id: pachitown
     name: "pachitown"
@@ -1934,7 +1934,7 @@ sites:
     url: "https://p-town.dmm.com"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://p-town.dmm.com/terms"
 
   - site_id: queen_work
     name: "queen_work"
@@ -1942,7 +1942,7 @@ sites:
     url: "https://queenwork.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://queenwork.jp/rules.html"
 
   - site_id: qzin
     name: "qzin"
@@ -1950,7 +1950,7 @@ sites:
     url: "https://qzin.jp/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.q-jin.careers/legal/tos.php"
 
   - site_id: tainyu_route
     name: "tainyu_route"
@@ -1958,7 +1958,7 @@ sites:
     url: "https://icondolllounge.jp/lists"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://icondolllounge.jp/privacy"
 
   - site_id: yashoku_gorakubu
     name: "yashoku_gorakubu"
@@ -1966,7 +1966,7 @@ sites:
     url: "https://yorushoku.jp/job-list/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://yorushoku.jp/terms-of-service/"
 
   - site_id: yorumachi
     name: "yorumachi"
@@ -1974,7 +1974,7 @@ sites:
     url: "https://yorumachi.jp/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://yorumachi.jp/company.html"
 
   - site_id: beauty_park
     name: "beauty_park"
@@ -1982,7 +1982,7 @@ sites:
     url: "https://www.beauty-park.jp/sitemap.xml"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.beauty-park.jp/pages/use_rule/"
 
   - site_id: bijipuri
     name: "bijipuri"
@@ -1990,7 +1990,7 @@ sites:
     url: "https://visipri.com/area_detail/index_exhibition_hall.php"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://visipri.com/privacy.html"
 
   - site_id: con_cafe
     name: "con_cafe"
@@ -1998,7 +1998,7 @@ sites:
     url: "https://con-cafe.jp"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://con-cafe.jp/rule"
 
   - site_id: fukui_shakou
     name: "fukui_shakou"
@@ -2006,7 +2006,7 @@ sites:
     url: "https://fukui-syakou.com/guide"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://fukui-syakou.com/privacy-policy"
 
   - site_id: gal_colle_net
     name: "gal_colle_net"
@@ -2014,7 +2014,7 @@ sites:
     url: "https://gal-colle.net"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://gal-colle.net/info_cr.php"
 
   - site_id: girlsbar_station
     name: "girlsbar_station"
@@ -2022,7 +2022,7 @@ sites:
     url: "https://girlsbar-station.com"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: imitsu
     name: "imitsu"
@@ -2030,7 +2030,7 @@ sites:
     url: "https://imitsu.jp/ct-sales-agent/search/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://imitsu.jp/terms/"
 
   - site_id: jalan_rentacar
     name: "jalan_rentacar"
@@ -2038,7 +2038,7 @@ sites:
     url: "https://www.jalan.net"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jalan.net/rentacar/statics/rentacarkiyaku.html"
 
   - site_id: jpon
     name: "jpon"
@@ -2046,7 +2046,7 @@ sites:
     url: "https://jpon.xyz/2012/index.html"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "http://www.jpon.jp/kiyaku.html"
 
   - site_id: kagoshima_shakou
     name: "kagoshima_shakou"
@@ -2054,7 +2054,7 @@ sites:
     url: "https://www.kagoshima-pub.or.jp/category/kagoshima/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "http://www.kagoshima-pub.or.jp/privacy-policy/"
 
   - site_id: nagano_shakou
     name: "nagano_shakou"
@@ -2062,7 +2062,7 @@ sites:
     url: "https://naganosyakouinshyoku.com/shoppost-cat/naganoshi"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://naganosyakouinshyoku.com/privacy-policy/"
 
   - site_id: niigata_shakou
     name: "niigata_shakou"
@@ -2070,7 +2070,7 @@ sites:
     url: "https://niigataken-shakou.com/search?keyword="
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "http://niigataken-shakou.com/policy"
 
   - site_id: okinawa_shakou
     name: "okinawa_shakou"
@@ -2078,7 +2078,7 @@ sites:
     url: "https://okinawasyako.ti-da.net/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: reshop_navi
     name: "reshop_navi"
@@ -2086,7 +2086,7 @@ sites:
     url: "https://rehome-navi.com/shops"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://rehome-navi.com/informations/terms"
 
   - site_id: savorjapan
     name: "savorjapan"
@@ -2094,7 +2094,7 @@ sites:
     url: "https://savorjapan.com"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://savorjapan.com/terms"
 
   - site_id: shizuoka_shakou
     name: "shizuoka_shakou"
@@ -2102,7 +2102,7 @@ sites:
     url: "https://shizuoka-shakou.com/shop"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://shizuoka-shakou.com/about/privacy"
 
   - site_id: toyama_shakou
     name: "toyama_shakou"
@@ -2110,7 +2110,7 @@ sites:
     url: "http://toyama-syakou.com/shop/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "http://toyama-syakou.com/privacy-policy/"
 
   - site_id: tsukulink_naisou
     name: "tsukulink_naisou"
@@ -2118,7 +2118,7 @@ sites:
     url: "https://tsukulink.net"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tsukulink.net/term"
 
   - site_id: aupay_japan
     name: "aupay_japan"
@@ -2126,7 +2126,7 @@ sites:
     url: "https://api.aupay.wallet.auone.jp/store-search"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://wallet.auone.jp/contents/pc/terms/"
 
   - site_id: aupay_store
     name: "aupay_store"
@@ -2134,7 +2134,7 @@ sites:
     url: "https://aupay.wallet.auone.jp/store/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://account.wowma.jp/docs/tos"
 
   - site_id: pps_net
     name: "pps_net"
@@ -2142,7 +2142,7 @@ sites:
     url: "https://pps-net.org/agency"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://pps-net.org/copyright"
 
   - site_id: xn_pckua2a7gp15o89zb
     name: "求人ボックス【外国人工場夜勤】"
@@ -2150,7 +2150,7 @@ sites:
     url: "https://xn--pckua2a7gp15o89zb.com"
     schedule: "0 8 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
   - site_id: sunmarie
     name: "サンマリエ"
@@ -2158,7 +2158,7 @@ sites:
     url: "https://www.sunmarie.co.jp/store/"
     schedule: "20 8 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.sunmarie.co.jp/privacy/"
 
   - site_id: sunmarie_2
     name: "サンマリエ"
@@ -2182,7 +2182,7 @@ sites:
     url: "https://www.jpnumber.com/"
     schedule: "20 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jpnumber.com/privacy.html"
 
   - site_id: milto
     name: "milto（ミルト）"
@@ -2190,7 +2190,7 @@ sites:
     url: "https://mil-to.com/"
     schedule: "0 3 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://mil-to.com/page/terms/"
 
   - site_id: tattoo_studio
     name: "タトゥースタジオナビ"
@@ -2198,7 +2198,7 @@ sites:
     url: "https://tattoo-navi.jp/studio/"
     schedule: "0 3 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tattoo-navi.jp/terms/"
 
   - site_id: jbn
     name: "JBN"
@@ -2206,7 +2206,7 @@ sites:
     url: "https://www.jbn-support.jp/about/search/"
     schedule: "0 19 26 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jbn-support.jp/privacy/"
 
   - site_id: cabanori
     name: "キャバノリ"
@@ -2214,7 +2214,7 @@ sites:
     url: "https://cabanori.com/top"
     schedule: "20 8 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cabanori.com/legal"
 
   - site_id: ibj_2
     name: "IBJ"
@@ -2222,7 +2222,7 @@ sites:
     url: "https://www.ibjapan.com/"
     schedule: "0 19 28 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ibjapan.jp/sitepolicy"
 
   - site_id: torecamap
     name: "トレカの地図"
@@ -2230,7 +2230,7 @@ sites:
     url: "https://torecamap.co.jp/"
     schedule: "0 21 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://torecamap.co.jp/rules"
 
   - site_id: kimonoya
     name: "着物屋さんナビ"
@@ -2238,7 +2238,7 @@ sites:
     url: "https://www.kimonoya.org/aboutme.html"
     schedule: "0 21 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.kimonoya.org/privacy.html"
 
   - site_id: hatarakuzo
     name: "働くぞドットコム"
@@ -2246,7 +2246,7 @@ sites:
     url: "https://www.hatarakuzo.com/"
     schedule: "0 17 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.hatarakuzo.com/pages/rule"
 
   - site_id: snakaranavi
     name: "スナカラ"
@@ -2254,7 +2254,7 @@ sites:
     url: "https://www.snakaranavi.net/"
     schedule: "0 19 2 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.snakaranavi.net/privacy.php"
 
   - site_id: techplaza
     name: "東大阪市技術交流プラザ"
@@ -2262,7 +2262,7 @@ sites:
     url: "https://www.techplaza.city.higashiosaka.osaka.jp/"
     schedule: "20 9 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.techplaza.city.higashiosaka.osaka.jp/help/notesonuse"
 
   - site_id: tsukulink_2
     name: "ツクリンクリスト"
@@ -2270,7 +2270,7 @@ sites:
     url: "https://tsukulink.net/"
     schedule: "20 9 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tsukulink.net/term"
 
   - site_id: night
     name: "神奈川夜遊びNight"
@@ -2278,7 +2278,7 @@ sites:
     url: "https://www.kanagawa-yoasobi.com/data.php?c=search&page=1"
     schedule: "0 9 15 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.kanagawa-yoasobi.com/data.php?c=policy"
 
   - site_id: enecho
     name: "登録小売電気事業者"
@@ -2286,7 +2286,7 @@ sites:
     url: "https://www.enecho.meti.go.jp/category/electricity_and_gas/electric/summary/retailers_list/index.html"
     schedule: "20 9 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.enecho.meti.go.jp/about/linksto_thissite/"
 
   - site_id: cabanori_3
     name: "ハマのり"
@@ -2294,7 +2294,7 @@ sites:
     url: "https://cabanori.com"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cabanori.com/legal"
 
   - site_id: web_2
     name: "web幹事"
@@ -2302,7 +2302,7 @@ sites:
     url: "https://web-kanji.com/search"
     schedule: "20 9 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://web-kanji.com/terms"
 
   - site_id: cookdoor_2
     name: "クックドア"
@@ -2310,7 +2310,7 @@ sites:
     url: "https://www.cookdoor.jp/"
     schedule: "20 9 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.homemate-research.com/info/rule/"
 
   - site_id: etsuran2_4
     name: "建設業者・宅建業者等企業情報検索システム【建設業者】"
@@ -2318,7 +2318,7 @@ sites:
     url: "https://etsuran2.mlit.go.jp/TAKKEN/kensetuKensaku.do?outPutKbn=1"
     schedule: "40 10 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.digital.go.jp/resources/open_data/public_data_license_v1.0"
 
   - site_id: tabiiro
     name: "旅色(宿)"
@@ -2326,7 +2326,7 @@ sites:
     url: "https://tabiiro.jp/yado/"
     schedule: "0 22 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://tabiiro.jp/regulation/"
 
   - site_id: wam
     name: "障害福祉サービス情報検索"
@@ -2334,7 +2334,7 @@ sites:
     url: "https://www.wam.go.jp/sfkohyoout/COP000100E0000.do"
     schedule: "0 19 7 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.wam.go.jp/content/wamnet/pcpub/syogai/shofukupubsys/shofukupubsys02.html"
 
   - site_id: kenken
     name: "KenKen!"
@@ -2342,7 +2342,7 @@ sites:
     url: "https://www.kenchikukenken.co.jp/"
     schedule: "0 18 7 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.kenchikukenken.co.jp/menseki.html"
 
   - site_id: clearing
     name: "登録貸金業者情報検索"
@@ -2350,7 +2350,7 @@ sites:
     url: "https://clearing.fsa.go.jp/kashikin/index.php"
     schedule: "0 18 6 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.fsa.go.jp/ordinary/kensaku/chuui.html"
 
   - site_id: search
     name: "金融商品取引業者等一覧"
@@ -2358,7 +2358,7 @@ sites:
     url: "https://search.fsa.go.jp/"
     schedule: "0 19 6 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.fsa.go.jp/rules/index.html"
 
   - site_id: etsuran2_5
     name: "建設業者・宅建業者等企業情報検索システム【マンション管理業者】"
@@ -2366,7 +2366,7 @@ sites:
     url: "https://etsuran2.mlit.go.jp/TAKKEN/mansionKensaku.do"
     schedule: "0 5 13 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.digital.go.jp/resources/open_data/public_data_license_v1.0"
 
   - site_id: keaj
     name: "在日中国朝鮮族経営者協会"
@@ -2374,7 +2374,7 @@ sites:
     url: "https://keaj.org/members/"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://keaj.org/privacy-policy"
 
   - site_id: caretaxi_net
     name: "介護タクシー案内所"
@@ -2382,7 +2382,7 @@ sites:
     url: "https://caretaxi-net.com/"
     schedule: "0 14 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://caretaxi-net.com/term/"
 
   - site_id: jcata
     name: "在日華人旅行業協会公式"
@@ -2390,7 +2390,7 @@ sites:
     url: "https://www.jcata.net/"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.churenkyo.com/churenkyo_kiyaku.html"
 
   - site_id: dancesagasu
     name: "ダンサガ"
@@ -2398,7 +2398,7 @@ sites:
     url: "https://dancesagasu.net/"
     schedule: "0 9 18 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://dancesagasu.net/rule/"
 
   - site_id: npo
     name: "内閣府NPO法人情報ポータルサイト"
@@ -2406,7 +2406,7 @@ sites:
     url: "https://www.npo-homepage.go.jp/npoportal/"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.npo-homepage.go.jp/npoportal/create/agreement"
 
   - site_id: kyujin
     name: "ほっとサーチ"
@@ -2414,7 +2414,7 @@ sites:
     url: "https://kyujin.hotsearch.jp/"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://kyujin.hotsearch.jp/kiyaku.html"
 
   - site_id: cabasite
     name: "cabasite"
@@ -2422,7 +2422,7 @@ sites:
     url: "https://cabasite.com/"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://cabasite.com/info.php?type=terms&id=TERMS"
 
   - site_id: iryou
     name: "医療情報ネット（ナビイ）"
@@ -2430,7 +2430,7 @@ sites:
     url: "https://www.iryou.teikyouseido.mhlw.go.jp/znk-web/juminkanja/S2300/initialize"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/kenkou_iryou/iryou/index_00004.html"
 
   - site_id: arukita
     name: "アルキタ"
@@ -2438,7 +2438,7 @@ sites:
     url: "https://www.arukita.com/job_list"
     schedule: "0 20 10 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.haj.co.jp/rules/?mediaid=1"
 
   - site_id: kaigoshoku
     name: "マイナビ介護職"
@@ -2446,7 +2446,7 @@ sites:
     url: "https://kaigoshoku.mynavi.jp/"
     schedule: "40 10 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://kaigoshoku.mynavi.jp/kiyaku"
 
   - site_id: demae_can_8
     name: "出前館"
@@ -2454,7 +2454,7 @@ sites:
     url: "https://demae-can.com/shopDetail"
     schedule: "0 1 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://demae-can.com/navigate/termsofuse"
 
   - site_id: jadma
     name: "JADMA 正会員一覧"
@@ -2462,7 +2462,7 @@ sites:
     url: "https://jadma.or.jp/membercompany/fmember"
     schedule: "40 10 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://jadma.or.jp/use"
 
   - site_id: re
     name: "Re就活"
@@ -2470,7 +2470,7 @@ sites:
     url: "https://re-katsu.jp/career/"
     schedule: "0 1 * * 6"
     enabled: true
-    terms_url: ""
+    terms_url: "https://re-katsu.jp/career/contents/kiyaku/index.html"
 
   - site_id: it
     name: "ITトレンド"
@@ -2478,7 +2478,7 @@ sites:
     url: "https://it-trend.jp/"
     schedule: "0 23 16 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://it-trend.jp/help/term"
 
   - site_id: boxil
     name: "BOXIL"
@@ -2486,7 +2486,7 @@ sites:
     url: "https://boxil.jp/"
     schedule: "0 20 30 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://boxil.jp/terms/"
 
   - site_id: emidas_2
     name: "エミダス(emidas)"
@@ -2494,7 +2494,7 @@ sites:
     url: "https://ja.nc-net.or.jp/?cntry=999"
     schedule: "0 18 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://emidas.jp/rule"
 
   - site_id: zenshukyo
     name: "全日本宗教用具協同組合(仏具)"
@@ -2502,7 +2502,7 @@ sites:
     url: "https://www.zenshukyo.or.jp/memberlist/"
     schedule: "0 9 18 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: softbank
     name: "ソフトバンクショップ"
@@ -2510,7 +2510,7 @@ sites:
     url: "https://www.softbank.jp/shop/search/"
     schedule: "40 10 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.softbank.jp/help/terms/"
 
   - site_id: www5
     name: "認定補聴器専門店認定システム"
@@ -2518,7 +2518,7 @@ sites:
     url: "https://www5.techno-aids.or.jp/shop/map.php"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "無し"
 
   - site_id: ii_ie2
     name: "いい家ネット"
@@ -2526,7 +2526,7 @@ sites:
     url: "https://www.ii-ie2.net/koumuten"
     schedule: "40 10 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ii-ie2.net/terms/"
 
   - site_id: p_portal
     name: "調達ポータル【法人】"
@@ -2534,7 +2534,7 @@ sites:
     url: "https://www.p-portal.go.jp/pps-web-biz/UAB01/OAB0103"
     schedule: "0 9 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.p-portal.go.jp/pps-web-biz/resources/app/pdf/riyoukiyaku.pdf"
 
   - site_id: epark
     name: "EPARKリラク＆エステ"
@@ -2542,7 +2542,7 @@ sites:
     url: "https://mitsuraku.jp/"
     schedule: "40 11 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://mitsuraku.jp/agreement/"
 
   - site_id: store
     name: "ほっともっと"
@@ -2550,7 +2550,7 @@ sites:
     url: "https://store.hottomotto.com/b/hottomotto/attr/"
     schedule: "0 2 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.hottomotto.com/policy/terms_of_use.html"
 
   - site_id: p_portal_4
     name: "調達ポータル【個人】"
@@ -2558,6 +2558,7 @@ sites:
     url: "https://www.p-portal.go.jp/pps-web-biz/UAB01/OAB0103"
     schedule: "40 11 22-28 * SAT"
     enabled: true
+    terms_url: "https://www.p-portal.go.jp/pps-web-biz/resources/app/pdf/riyoukiyaku.pdf"
 
   - site_id: catr
     name: "官報"
@@ -2565,6 +2566,7 @@ sites:
     url: "https://catr.jp/"
     schedule: "0 3 19 * *"
     enabled: true
+    terms_url: "https://search.npb.go.jp/guide/kiyaku.html"
 
   - site_id: ntt
     name: "NTT東日本 光コラボレーションモデル 事業者一覧"
@@ -2572,6 +2574,7 @@ sites:
     url: "https://flets.com/collabo/list/"
     schedule: "40 11 22-28 * SUN"
     enabled: true
+    terms_url: "https://flets.com/requirements.html"
 
   - site_id: ntt_2
     name: "NTT西日本 光コラボレーションモデル 事業者一覧"
@@ -2579,6 +2582,7 @@ sites:
     url: "https://flets-w.com/collabo/list/index.php"
     schedule: "0 11 1-7 * SAT"
     enabled: true
+    terms_url: "https://www.ntt-west.co.jp/share/aboutsite.html"
 
   - site_id: houjin_bangou
     name: "国税庁　法人番号公表サイト"
@@ -2586,6 +2590,7 @@ sites:
     url: "https://www.houjin-bangou.nta.go.jp/"
     schedule: "0 11 1-7 * SUN"
     enabled: true
+    terms_url: "https://www.houjin-bangou.nta.go.jp/riyokiyaku/index.html"
 
   - site_id: baitoru_2
     name: "(バイトル)　ほっともっと"
@@ -2593,6 +2598,7 @@ sites:
     url: "https://www.baitoru.com/"
     schedule: "0 11 8-14 * SAT"
     enabled: true
+    terms_url: "https://www.baitoru.com/about/kiyaku_base.html"
 
   - site_id: bar_navi
     name: "バーナビ　 BAR-NAVI"
@@ -2600,6 +2606,7 @@ sites:
     url: "https://bar-navi.suntory.co.jp/"
     schedule: "0 12 8-14 * SUN"
     enabled: true
+    terms_url: "https://bar-navi.suntory.co.jp/terms.html"
 
   - site_id: bar_find
     name: "バーファインド"
@@ -2607,6 +2614,7 @@ sites:
     url: "https://bar-find.com/"
     schedule: "0 12 15-21 * SAT"
     enabled: true
+    terms_url: "https://bar-find.com/main/terms_user"
 
   - site_id: brunavi
     name: "ブルナビ"
@@ -2614,6 +2622,7 @@ sites:
     url: "https://brunavi.com/"
     schedule: "0 12 15-21 * SUN"
     enabled: true
+    terms_url: "https://brunavi.com/?mode=policy"
 
   - site_id: xn_pckua2a7gp15o89zb_2
     name: "求人ボックス（ナイトワーク系求人）"
@@ -2621,6 +2630,7 @@ sites:
     url: "https://xn--pckua2a7gp15o89zb.com/"
     schedule: "0 12 22-28 * SAT"
     enabled: true
+    terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
   - site_id: jp
     name: "スタンバイ"
@@ -2628,6 +2638,7 @@ sites:
     url: "https://jp.stanby.com/"
     schedule: "0 12 22-28 * SUN"
     enabled: true
+    terms_url: "https://jp.stanby.com/about/terms"
 
   - site_id: nomu
     name: "ノムノム"
@@ -2642,6 +2653,7 @@ sites:
     url: "https://www.snack-guide.com/"
     schedule: "20 13 1-7 * SUN"
     enabled: true
+    terms_url: "無し"
 
   - site_id: cabanavi
     name: "キャバナビ"
@@ -2649,6 +2661,7 @@ sites:
     url: "https://cabanavi.info/shops/tohoku/"
     schedule: "20 13 8-14 * SAT"
     enabled: true
+    terms_url: "https://cabanavi.info/navi/page/4395/"
 
   - site_id: town_night
     name: "夜遊びショコラ（東北）"
@@ -2656,6 +2669,7 @@ sites:
     url: "https://town-night.jp/miyagi/"
     schedule: "20 13 8-14 * SUN"
     enabled: true
+    terms_url: "https://town-night.jp/terms/"
 
   - site_id: web_3
     name: "ルーキーWeb"
@@ -2663,6 +2677,7 @@ sites:
     url: "https://www.shigotoarimasu.com/"
     schedule: "20 13 15-21 * SAT"
     enabled: true
+    terms_url: "https://www.shigotoarimasu.com/article/303"
 
   - site_id: noxgroup
     name: "ノックスグループ"
@@ -2670,6 +2685,7 @@ sites:
     url: "https://noxgroup.jp/"
     schedule: "20 14 15-21 * SUN"
     enabled: true
+    terms_url: "https://www.noxgroup2021.com/policy"
 
   - site_id: agre
     name: "Agre"
@@ -2677,6 +2693,7 @@ sites:
     url: "https://webagre.com/"
     schedule: "20 14 22-28 * SAT"
     enabled: true
+    terms_url: "https://webagre.com/job/terms_of_service"
 
   - site_id: nightgram
     name: "ナイトグラム"
@@ -2684,6 +2701,7 @@ sites:
     url: "https://nightgram.com/"
     schedule: "20 14 22-28 * SUN"
     enabled: true
+    terms_url: "https://nightgram.com/terms"
 
   - site_id: ac_lab
     name: "アクセス就活2027"
@@ -2691,6 +2709,7 @@ sites:
     url: "https://www.ac-lab.jp/2027/front/top/top.html"
     schedule: "40 14 1-7 * SAT"
     enabled: true
+    terms_url: "https://www.ac-lab.jp/media/rule_ac/"
 
   - site_id: tsunoru
     name: "TSUNORU既卒第二新卒"
@@ -2698,6 +2717,7 @@ sites:
     url: "https://job.tsunoru.jp/prev/"
     schedule: "40 14 1-7 * SUN"
     enabled: true
+    terms_url: "https://job.tsunoru.jp/doc/terms_company.pdf"
 
   - site_id: night_works
     name: "キャバクラ求人ホッケ"
@@ -2705,6 +2725,7 @@ sites:
     url: "https://night-works.com/"
     schedule: "0 9 5 * *"
     enabled: true
+    terms_url: "https://night-works.com/privacypolicy/"
 
   - site_id: webagre
     name: "アグレキャリア"
@@ -2712,6 +2733,7 @@ sites:
     url: "https://webagre.com/career"
     schedule: "40 15 8-14 * SAT"
     enabled: true
+    terms_url: "https://webagre.com/career/membership_agreement"
 
   - site_id: https_bunbunweb_com_shop
     name: "BunBunweb_国分町"
@@ -2719,6 +2741,7 @@ sites:
     url: "https://bunbunweb.com/shop/455/"
     schedule: "0 4 5 * *"
     enabled: true
+    terms_url: "無し"
 
   - site_id: luline
     name: "夜のお店選びドットコム（東北版）"
@@ -2726,6 +2749,7 @@ sites:
     url: "https://luline.jp/tohoku/shop_list/search/"
     schedule: "40 15 8-14 * SUN"
     enabled: true
+    terms_url: "https://tainew-tohoku.com/menu/terms/"
 
   - site_id: re30
     name: "Re就活30"
@@ -2733,6 +2757,7 @@ sites:
     url: "https://re-katsu30.jp/search/result?income%5B0%5D=&income%5B1%5D=&btn_search=1"
     schedule: "40 15 15-21 * SAT"
     enabled: true
+    terms_url: "https://re-katsu30.jp/kiyaku/"
 
   - site_id: pacola
     name: "パコラ"
@@ -2740,6 +2765,7 @@ sites:
     url: "https://www.pacola.co.jp/recruitment_special/"
     schedule: "40 15 15-21 * SUN"
     enabled: true
+    terms_url: "https://www.pacola.co.jp/privacy/"
 
   - site_id: job
     name: "メリット"
@@ -2747,6 +2773,7 @@ sites:
     url: "https://job.merit-inc.net/job_offering/job_offerings/search?area_id_1=&area_id_2=&area_id_3=&area_id_4=&employment_id=&job_id=&time_id=&tag_id=&x=163&y=50#pageTitleH1"
     schedule: "40 15 22-28 * SAT"
     enabled: true
+    terms_url: "https://www.merit-inc.co/privacy/"
 
   - site_id: i_select
     name: "iセレクト"
@@ -2754,6 +2781,7 @@ sites:
     url: "http://www.i-select.jp/search"
     schedule: "40 15 22-28 * SUN"
     enabled: true
+    terms_url: "http://www.i-select.jp/terms"
 
   - site_id: atsumaru
     name: "あつまるくんの求人案内"
@@ -2761,6 +2789,7 @@ sites:
     url: "https://atsumaru.jp/all/list?utf8=%E2%9C%93&s%5Bkw%5D="
     schedule: "0 16 1-7 * SAT"
     enabled: true
+    terms_url: "https://atsumaru.jp/terms"
 
   - site_id: e_aidem
     name: "イーアイデム【全国】"
@@ -2768,6 +2797,7 @@ sites:
     url: "https://www.e-aidem.com/?show=1"
     schedule: "0 16 1-7 * SUN"
     enabled: true
+    terms_url: "https://www.e-aidem.com/contents/info/kiyaku.htm"
 
   - site_id: e_arpa
     name: "アルパ"
@@ -2775,6 +2805,7 @@ sites:
     url: "https://www.e-arpa.jp/"
     schedule: "0 16 8-14 * SAT"
     enabled: true
+    terms_url: "https://www.kg-net.co.jp/information/service-rule.php"
 
   - site_id: workin
     name: "workin岡山県"
@@ -2782,6 +2813,7 @@ sites:
     url: "https://workin.jp/okayama/search?srchBtn=1"
     schedule: "0 16 8-14 * SUN"
     enabled: true
+    terms_url: "https://workin.jp/static/kiyaku"
 
   - site_id: keeperproshop
     name: "KeePerPROSHOP_洗車関連"
@@ -2789,6 +2821,7 @@ sites:
     url: "https://www.keepercoating.jp/proshop"
     schedule: "0 9 13 * *"
     enabled: true
+    terms_url: "https://www.keepercoating.jp/privacy/"
 
   - site_id: d_starjob
     name: "ディースターネット"
@@ -2796,6 +2829,7 @@ sites:
     url: "https://d-starjob.com/"
     schedule: "0 16 15-21 * SAT"
     enabled: true
+    terms_url: "https://d-starjob.com/etc/kiyaku.html"
 
   - site_id: domo_2
     name: "DOMO静岡"
@@ -2803,6 +2837,7 @@ sites:
     url: "https://domonet.jp/shizuoka/list"
     schedule: "0 17 15-21 * SUN"
     enabled: true
+    terms_url: "https://domonet.jp/info/agreement"
 
   - site_id: ad_sanai
     name: "アドサンアイ"
@@ -2810,6 +2845,7 @@ sites:
     url: "https://www.ad-sanai.co.jp/job-search?area=All&pref=All&city=All&field_job_salary_system_value=All&field_job_salary_time=All&field_job_salary_day=All&field_job_salary_month=All&field_job_salary_year=All&station_name=&keyword="
     schedule: "0 17 22-28 * SAT"
     enabled: true
+    terms_url: "https://www.ad-sanai.co.jp/goriyou"
 
   - site_id: domo_net
     name: "DOMO NET(ドモネット)"
@@ -2817,6 +2853,7 @@ sites:
     url: "https://domonet.jp/kanto"
     schedule: "0 17 22-28 * SUN"
     enabled: true
+    terms_url: "https://domonet.jp/info/agreement"
 
   - site_id: club_jt
     name: "CLUB　JT"
@@ -2824,6 +2861,7 @@ sites:
     url: "https://www.clubjt.jp/place/spot/"
     schedule: "20 17 1-7 * SAT"
     enabled: true
+    terms_url: "https://www.clubjt.jp/terms/clubjt-terms/"
 
   - site_id: jp_2
     name: "スタンバイ　ナイトワーク"
@@ -2831,6 +2869,7 @@ sites:
     url: "https://jp.stanby.com/"
     schedule: "20 17 1-7 * SUN"
     enabled: true
+    terms_url: "https://standby-corp.jp/standby-terms-of-use/"
 
   - site_id: jobkita
     name: "ジョブキタ"
@@ -2838,6 +2877,7 @@ sites:
     url: "https://www.jobkita.jp/job/list/"
     schedule: "0 9 18 * *"
     enabled: true
+    terms_url: "https://www.haj.co.jp/rules/?mediaid=3"
 
   - site_id: sgnavi
     name: "sgnavi"
@@ -2845,6 +2885,7 @@ sites:
     url: "https://www.sgnavi.com/hokkaido/job-list/"
     schedule: "20 18 8-14 * SAT"
     enabled: true
+    terms_url: "https://www.sgnavi.com/hokkaido/terms-of-service/"
 
   - site_id: yell
     name: "エール"
@@ -2852,6 +2893,7 @@ sites:
     url: "https://herp.careers/v1/yell"
     schedule: "0 5 * * 1"
     enabled: true
+    terms_url: "https://herp.careers/careers/terms"
 
   - site_id: girls_good_job
     name: "girls good job"
@@ -2859,6 +2901,7 @@ sites:
     url: "https://girls-good-job.jp/"
     schedule: "0 22 18 * *"
     enabled: true
+    terms_url: "無し"
 
   - site_id: tainew_walker
     name: "体入キャストウォーカー"
@@ -2866,6 +2909,7 @@ sites:
     url: "https://tainew-walker.jp/"
     schedule: "0 19 8 * *"
     enabled: true
+    terms_url: "https://tainew-walker.jp/rule"
 
  
 
@@ -2875,6 +2919,7 @@ sites:
     url: "https://luline.jp/top/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "https://luline.jp/about/terms/"
 
   - site_id: kensetsu_databank
     name: "建築計画のお知らせ看板情報【首都圏】"
@@ -2882,6 +2927,7 @@ sites:
     url: "https://www.kensetsu-databank.co.jp/"
     schedule: "0 18 28 * *"
     enabled: true
+    terms_url: "https://www.kensetsu-databank.co.jp/privacy/"
 
   - site_id: girlswork
     name: "がーるずわーく"
@@ -2889,6 +2935,7 @@ sites:
     url: "https://girlswork.jp/"
     schedule: "0 16 26 * *"
     enabled: true
+    terms_url: "https://girlswork.jp/terms-of-service/"
 
   - site_id: kensetsu_databank_2
     name: "建築計画のお知らせ看板情報"
@@ -2896,6 +2943,7 @@ sites:
     url: "https://www.kensetsu-databank.co.jp/"
     schedule: "0 19 1 * *"
     enabled: true
+    terms_url: "https://kdb.tokyo/aboutus/privacy.html"
 
   - site_id: con_girl
     name: "コンガール"
@@ -2903,6 +2951,7 @@ sites:
     url: "https://con-girl.com/"
     schedule: "0 13 27 * *"
     enabled: true
+    terms_url: "https://con-girl.com/userpolicy"
 
   - site_id: tainew
     name: "体入ドットコム"
@@ -2910,6 +2959,7 @@ sites:
     url: "https://www.tainew.com/"
     schedule: "0 9 11 * *"
     enabled: true
+    terms_url: "https://www.tainew.com/menu/terms/"
 
   - site_id: jasmac8
     name: "ジャスマック八戸館"
@@ -2917,6 +2967,7 @@ sites:
     url: "https://www.jasmac8.com/sitemap.html"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "無し"
 
   - site_id: japanshishatimes
     name: "シーシャマップジャパン"
@@ -2924,6 +2975,7 @@ sites:
     url: "https://www.japanshishatimes.jp/shoplist"
     schedule: "20 18 8-14 * SUN"
     enabled: true
+    terms_url: "https://www.japanshishatimes.jp/terms-of-use"
 
   - site_id: prefer_work
     name: "Prefer Work"
@@ -2931,6 +2983,7 @@ sites:
     url: "https://offer-prefer.site/"
     schedule: "0 16 17 * *"
     enabled: true
+    terms_url: "https://offer-prefer.site/policy/"
 
   - site_id: ekimae_lab
     name: "エキラボ"
@@ -2938,6 +2991,7 @@ sites:
     url: "https://ekimae-lab.com/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "無し"
 
   - site_id: foul
     name: "ファウルプラチナム"
@@ -2945,6 +2999,7 @@ sites:
     url: "https://www.foul.co.jp/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "無し"
 
   - site_id: navi_2
     name: "便利屋さんNAVI"
@@ -2952,6 +3007,7 @@ sites:
     url: "https://benriyanavi.com/"
     schedule: "0 0 1 * *"
     enabled: true
+    terms_url: "https://benriyanavi.com/disclaimer.html"
 
   - site_id: nightstyle_2
     name: "ナイト_ナイトスタイル"
@@ -2959,6 +3015,7 @@ sites:
     url: "https://nightstyle.jp/g7/"
     schedule: "20 18 15-21 * SAT"
     enabled: true
+    terms_url: "https://nightstyle.jp/terms/"
 
   - site_id: girlsbar_prds
     name: "ガルバパラダイス"
@@ -2966,6 +3023,7 @@ sites:
     url: "https://girlsbar-prds.net/"
     schedule: "20 18 15-21 * SUN"
     enabled: true
+    terms_url: "https://girlsbar-prds.net/grp/Terms.html"
 
   - site_id: benriya_paradise
     name: "便利屋パラダイス"
@@ -2973,6 +3031,7 @@ sites:
     url: "https://benriya-paradise.com/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "https://benriya-paradise.com/terms"
 
   - site_id: helper
     name: "便利屋お助けナビ"
@@ -2980,6 +3039,7 @@ sites:
     url: "https://helper.kokoroegao.com/"
     schedule: "0 1 8 * *"
     enabled: true
+    terms_url: "https://helper.kokoroegao.com/terms/"
 
   - site_id: benriya_paradise_2
     name: "便利屋 パラダイス"
@@ -2987,6 +3047,7 @@ sites:
     url: "https://benriya-paradise.com/"
     schedule: "20 18 22-28 * SAT"
     enabled: true
+    terms_url: "https://benriya-paradise.com/terms"
 
   - site_id: navi_3
     name: "便利屋さん NAVI"
@@ -2994,6 +3055,7 @@ sites:
     url: "https://benriyanavi.com/?utm_source=chatgpt.com"
     schedule: "20 19 22-28 * SUN"
     enabled: true
+    terms_url: "https://benriyanavi.com/disclaimer.html"
 
   - site_id: helper_2
     name: "便利屋お助け ナビ"
@@ -3001,6 +3063,7 @@ sites:
     url: "https://helper.kokoroegao.com/?post_type=helperinfo"
     schedule: "40 19 1-7 * SAT"
     enabled: true
+    terms_url: "https://helper.kokoroegao.com/terms/"
 
   - site_id: jobmake
     name: "ジョブメイク"
@@ -3008,6 +3071,7 @@ sites:
     url: "https://www.jobmake.jp/48/search?gf=f&kt=t"
     schedule: "40 19 1-7 * SUN"
     enabled: true
+    terms_url: "https://www.jobmake.jp/privacy"
 
   - site_id: mycareer_jp
     name: "ミツケル"
@@ -3015,6 +3079,7 @@ sites:
     url: "https://mycareer-jp.com/area/FW"
     schedule: "40 19 8-14 * SAT"
     enabled: true
+    terms_url: "https://mitsukel.co.jp/terms/"
 
   - site_id: builders_ranking
     name: "ビルダーランキング"
@@ -3022,6 +3087,7 @@ sites:
     url: "https://builders-ranking.com/"
     schedule: "0 12 25 * *"
     enabled: true
+    terms_url: "無し"
 
   - site_id: nap_camp
     name: "なっぷ"
@@ -3029,6 +3095,7 @@ sites:
     url: "https://www.nap-camp.com/"
     schedule: "40 19 8-14 * SUN"
     enabled: true
+    terms_url: "https://www.nap-camp.com/support_data/terms/6_nap_agreement.pdf"
 
   - site_id: nextinjapan
     name: "nextinjapan"
@@ -3036,6 +3103,7 @@ sites:
     url: "https://nextinjapan.com/jobs"
     schedule: "40 19 15-21 * SAT"
     enabled: true
+    terms_url: "https://nextinjapan.com/terms"
 
   - site_id: q_jinkun
     name: "求人君"
@@ -3043,6 +3111,7 @@ sites:
     url: "https://www.q-jinkun.com/?mode=ds"
     schedule: "40 20 15-21 * SUN"
     enabled: true
+    terms_url: "https://www.q-jinkun.com/privacypolicy/"
 
   - site_id: workinfree
     name: "WorkinFree"
@@ -3050,6 +3119,7 @@ sites:
     url: "https://workin.jp/"
     schedule: "40 20 22-28 * SAT"
     enabled: true
+    terms_url: "https://workin.jp/static/kiyaku"
 
   - site_id: re_2
     name: "Re就活（やり直し）"
@@ -3057,6 +3127,7 @@ sites:
     url: "https://re-katsu.jp/career/"
     schedule: "40 20 22-28 * SUN"
     enabled: true
+    terms_url: "https://re-katsu.jp/career/contents/kiyaku/index.html"
 
   - site_id: navi_4
     name: "片町ナイトNAVI"
@@ -3064,6 +3135,7 @@ sites:
     url: "https://k-navi.happyjob.jp/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "無し"
 
   - site_id: guide_jp
     name: "浜松ナイトガイド"
@@ -3071,6 +3143,7 @@ sites:
     url: "https://guide-jp.com/hamamatsu-night/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "https://guide-jp.com/guideline/"
 
   - site_id: matsumoto_angel
     name: "長野ナイトナビ"
@@ -3078,6 +3151,7 @@ sites:
     url: "https://www.matsumoto-angel.net/night/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "https://www.matsumoto-angel.net/night/static/info/rule.html"
 
   - site_id: kofu_angel
     name: "山梨ナイトナビ"
@@ -3085,6 +3159,7 @@ sites:
     url: "https://www.kofu-angel.net/night/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "https://www.kofu-angel.net/fuuzoku/rule/"
 
   - site_id: cabasite_2
     name: "キャバサイト"
@@ -3092,6 +3167,7 @@ sites:
     url: "https://cabasite.com/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "https://cabasite.com/info.php?type=terms&id=TERMS"
 
   - site_id: pokepara
     name: "ポケパラ"
@@ -3099,6 +3175,7 @@ sites:
     url: "https://www.pokepara.jp/"
     schedule: "0 9 1 * *"
     enabled: true
+    terms_url: "https://www.pokepara.jp/kanto/agree.html"
 
   - site_id: good_staff
     name: "Good Staff"
@@ -3106,6 +3183,7 @@ sites:
     url: "https://good-staff-recruit.jp/-/top/index.html"
     schedule: "0 9 17 * *"
     enabled: true
+    terms_url: "https://entori.jp/goodstaff/rules"
 
   - site_id: bizcomm
     name: "ビズコミ"
@@ -3113,6 +3191,7 @@ sites:
     url: "https://bizcomm.net/"
     schedule: "0 20 1-7 * SAT"
     enabled: true
+    terms_url: "https://bizcomm.net/terms-of-service"
 
   - site_id: shigoto100
     name: "日本仕事百貨"
@@ -3120,6 +3199,7 @@ sites:
     url: "https://shigoto100.com/job"
     schedule: "0 14 19 * *"
     enabled: true
+    terms_url: "https://shigoto100.com/userpolicy"
 
   - site_id: myhome
     name: "ニフティ不動産（不動産会社・不動産屋を探す）"
@@ -3127,6 +3207,7 @@ sites:
     url: "https://myhome.nifty.com/shop/"
     schedule: "0 20 1-7 * SUN"
     enabled: true
+    terms_url: "https://niftylifestyle.co.jp/term/myhome/"
 
   - site_id: job_2
     name: "彩job"
@@ -3134,6 +3215,7 @@ sites:
     url: "https://kyujin-saitama.com/2026-2027list/"
     schedule: "0 9 29 * *"
     enabled: true
+    terms_url: "無し"
 
   - site_id: jobway
     name: "Jobway"
@@ -3141,6 +3223,7 @@ sites:
     url: "https://www.jobway.jp/index/current"
     schedule: "0 9 9 * *"
     enabled: true
+    terms_url: "https://www.jobway.jp/terms"
 
   - site_id: bizreach_2
     name: "ビズリーチ"

--- a/sites.yml
+++ b/sites.yml
@@ -3391,7 +3391,7 @@ sites:
     url: "https://crowdworks.jp/public/jobs?ref=public_header"
     schedule: "40 23 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://crowdworks.jp/pages/agreement"
 
   - site_id: zexy
     name: "ゼクシィ"

--- a/sites.yml
+++ b/sites.yml
@@ -2646,6 +2646,7 @@ sites:
     url: "https://nomu.tsuku2.jp/c8"
     schedule: "20 13 1-7 * SAT"
     enabled: true
+    terms_url: "https://home.tsuku2.jp/terms.php"
 
   - site_id: snack_guide
     name: "スナックガイド"
@@ -3231,12 +3232,14 @@ sites:
     url: "https://www.bizreach.jp/"
     schedule: "0 17 28 * *"
     enabled: true
+    terms_url: ""
 
   - site_id: paiza
     name: "paiza"
     module: "jobs.paiza"
     url: "https://paiza.jp/career/job_offers"
     schedule: "0 17 10 * *"
+    terms_url: ""
 
   - site_id: mynavi_baito
     name: "マイナビバイト"
@@ -3252,6 +3255,7 @@ sites:
     url: "https://www.froma.com/?red=0"
     schedule: "0 9 11 * *"
     enabled: true
+    terms_url: ""
 
   - site_id: 01intern
     name: "ゼロワンインターン"
@@ -3259,6 +3263,7 @@ sites:
     url: "https://01intern.com/job/list.html?areas=999999999&areas=13&areas=14&areas=12&areas=11&areas=27&areas=26&areas=28&areas=8&areas=1&areas=3&areas=4&areas=10&areas=9&areas=19&areas=15&areas=20&areas=16&areas=17&areas=21&areas=22&areas=23&areas=24&areas=25&areas=29&areas=30&areas=32&areas=33&areas=34&areas=35&areas=37&areas=38&areas=39&areas=40&areas=41&areas=42&areas=43&areas=44&areas=46&areas=47&areas=48"
     schedule: "0 21 8-14 * SAT"
     enabled: true
+    terms_url: ""
 
   - site_id: job_3
     name: "キャリタス就活"
@@ -3266,6 +3271,7 @@ sites:
     url: "https://job.career-tasu.jp/condition-search/result/?keyword="
     schedule: "0 21 8-14 * SUN"
     enabled: true
+    terms_url: ""
 
   - site_id: bunnabi
     name: "ブンナビ(2027)"
@@ -3273,6 +3279,7 @@ sites:
     url: "https://bunnabi.jp/2027/sh_result.php"
     schedule: "0 21 15-21 * SAT"
     enabled: true
+    terms_url: ""
 
   - site_id: emeao
     name: "エミーオ(EMEAO)"
@@ -3280,6 +3287,7 @@ sites:
     url: "https://emeao.jp/search/"
     schedule: "0 21 15-21 * SUN"
     enabled: true
+    terms_url: ""
 
   - site_id: metoree
     name: "Metoree（メトリー）"
@@ -3287,6 +3295,7 @@ sites:
     url: "https://metoree.com/companies/"
     schedule: "0 21 22-28 * SAT"
     enabled: true
+    terms_url: ""
 
   - site_id: mitsuri
     name: "Mitsuri(ミツリ)"
@@ -3294,6 +3303,7 @@ sites:
     url: "https://app.mitsu-ri.net/pblc/suppliers?_gl=1*wczuq3*_ga*MTg0MTM0NDU5MS4xNzgyNzg2NDg5*_ga_SQCQZHNTCS*czE3ODI3ODY0ODgkbzEkZzEkdDE3ODI3ODgyMTckajMyJGwwJGgw"
     schedule: "0 22 22-28 * SUN"
     enabled: true
+    terms_url: ""
 
   - site_id: town_life
     name: "タウンライフリフォーム"
@@ -3301,6 +3311,7 @@ sites:
     url: "https://www.town-life.jp/home/main/chatform.php"
     schedule: "20 22 1-7 * SAT"
     enabled: true
+    terms_url: ""
 
   - site_id: lifull_home_s
     name: "LIFULL HOME'S 注文住宅(ライフルホームズ)"
@@ -3308,6 +3319,7 @@ sites:
     url: "https://www.homes.co.jp/realtor/"
     schedule: "20 22 1-7 * SUN"
     enabled: true
+    terms_url: ""
 
   - site_id: hikkoshizamurai
     name: "引越し侍"
@@ -3315,6 +3327,7 @@ sites:
     url: "https://hikkoshizamurai.jp/company/"
     schedule: "20 22 8-14 * SAT"
     enabled: true
+    terms_url: ""
 
   - site_id: relax_job
     name: "リジョブ"
@@ -3322,6 +3335,7 @@ sites:
     url: "https://relax-job.com/"
     schedule: "0 17 19 * *"
     enabled: true
+    terms_url: ""
 
   - site_id: e_sogi
     name: "いい葬儀"
@@ -3329,6 +3343,7 @@ sites:
     url: "https://www.e-sogi.com/"
     schedule: "20 22 8-14 * SUN"
     enabled: true
+    terms_url: ""
 
   - site_id: osohshiki
     name: "小さなお葬式"
@@ -3336,6 +3351,7 @@ sites:
     url: "https://www.osohshiki.jp/area/"
     schedule: "20 23 15-21 * SAT"
     enabled: true
+    terms_url: ""
 
   - site_id: zeiri4
     name: "税理士ドットコム"
@@ -3343,6 +3359,7 @@ sites:
     url: "https://www.zeiri4.com/firm/search/?FirmSearchForm%5BPrefecture_id%5D=&FirmSearchForm%5BAutonomy_id%5D="
     schedule: "20 23 15-21 * SUN"
     enabled: true
+    terms_url: ""
 
   - site_id: bengo4
     name: "弁護士ドットコム"
@@ -3350,6 +3367,7 @@ sites:
     url: "https://www.bengo4.com/search/result/"
     schedule: "20 23 22-28 * SAT"
     enabled: true
+    terms_url: ""
 
   - site_id: hanayume
     name: "HANAYUME(ハナユメ)"
@@ -3357,6 +3375,7 @@ sites:
     url: "https://hana-yume.net/search/hallList/?sg_hs%5Barea%5D=&sg_hs%5Border%5D=&sg_hs%5BsearchKind%5D="
     schedule: "20 23 22-28 * SUN"
     enabled: true
+    terms_url: ""
 
   - site_id: eslove
     name: "エステラブ"
@@ -3364,6 +3383,7 @@ sites:
     url: "https://eslove.jp"
     schedule: "0 9 7 * *"
     enabled: true
+    terms_url: ""
 
   - site_id: crowdworks
     name: "クラウドワークス"
@@ -3371,6 +3391,7 @@ sites:
     url: "https://crowdworks.jp/public/jobs?ref=public_header"
     schedule: "40 23 1-7 * SAT"
     enabled: true
+    terms_url: ""
 
   - site_id: zexy
     name: "ゼクシィ"
@@ -3378,6 +3399,7 @@ sites:
     url: "https://zexy.net/"
     schedule: null
     enabled: true
+    terms_url: ""
 
   - site_id: baitoru_5
     name: "バイトル関西_工場"
@@ -3385,6 +3407,7 @@ sites:
     url: "https://www.baitoru.com/kansai/jlist/"
     schedule: "0 9 * * 1"
     enabled: true
+    terms_url: ""
 
   - site_id: sumitec_kanto_2
     name: "リンクスアシスト"
@@ -3392,6 +3415,7 @@ sites:
     url: "https://sumitec-kanto.com/page/1?s"
     schedule: "0 9 * * 1"
     enabled: true
+    terms_url: ""
 
   - site_id: ciic
     name: "CIIC"
@@ -3399,6 +3423,7 @@ sites:
     url: "https://www.ciic.or.jp/"
     schedule: "0 9 24 * 0"
     enabled: true
+    terms_url: ""
 
   - site_id: hapisumu
     name: "ハピすむ（リフォーム加盟店）"
@@ -3406,6 +3431,7 @@ sites:
     url: "https://hapisumu.jp/"
     schedule: "0 20 13 * *"
     enabled: true
+    terms_url: ""
 
   - site_id: gaiheki_madoguchi
     name: "外壁塗装の窓口"
@@ -3413,6 +3439,7 @@ sites:
     url: "https://gaiheki-madoguchi.com/"
     schedule: null
     enabled: true
+    terms_url: ""
 
   - site_id: lancers
     name: "サンラーズ"
@@ -3420,3 +3447,4 @@ sites:
     url: "https://www.lancers.jp/"
     schedule: null
     enabled: true
+    terms_url: ""

--- a/sites.yml
+++ b/sites.yml
@@ -823,7 +823,7 @@ sites:
     url: "https://ai-med.jp/"
     schedule: "20 7 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://ai-med.jp/clause"
 
   - site_id: asoview
     name: "アソビュー"
@@ -2167,14 +2167,14 @@ sites:
     schedule: "20 8 1-7 * SUN"
     enabled: true
     
-    terms_url: ""
+    terms_url: "https://www.sunmarie.co.jp/copyright/"
   - site_id: ibj_members
     name: "IBJメンバーズ（結婚相談所）"
     module: "service.ibj_members"
     url: "https://www.loungemembers.com/lounge"
     schedule: "0 4 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ibjapan.jp/individual_renmei_lounge"
 
   - site_id: jpnumber_power_agents
     name: "新電力代理店候補 JPNumber"
@@ -3232,7 +3232,7 @@ sites:
     url: "https://www.bizreach.jp/"
     schedule: "0 17 28 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.bizreach.jp/pages/service/rules/"
 
   - site_id: paiza
     name: "paiza"
@@ -3255,7 +3255,7 @@ sites:
     url: "https://www.froma.com/?red=0"
     schedule: "0 9 11 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.help.froma.com/s/article/000025050"
 
   - site_id: 01intern
     name: "ゼロワンインターン"
@@ -3263,7 +3263,7 @@ sites:
     url: "https://01intern.com/job/list.html?areas=999999999&areas=13&areas=14&areas=12&areas=11&areas=27&areas=26&areas=28&areas=8&areas=1&areas=3&areas=4&areas=10&areas=9&areas=19&areas=15&areas=20&areas=16&areas=17&areas=21&areas=22&areas=23&areas=24&areas=25&areas=29&areas=30&areas=32&areas=33&areas=34&areas=35&areas=37&areas=38&areas=39&areas=40&areas=41&areas=42&areas=43&areas=44&areas=46&areas=47&areas=48"
     schedule: "0 21 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://01intern.com/terms.html"
 
   - site_id: job_3
     name: "キャリタス就活"
@@ -3271,7 +3271,7 @@ sites:
     url: "https://job.career-tasu.jp/condition-search/result/?keyword="
     schedule: "0 21 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://job.career-tasu.jp/membership-agreement/"
 
   - site_id: bunnabi
     name: "ブンナビ(2027)"
@@ -3287,7 +3287,7 @@ sites:
     url: "https://emeao.jp/search/"
     schedule: "0 21 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://emeao.jp/policy/"
 
   - site_id: metoree
     name: "Metoree（メトリー）"
@@ -3295,7 +3295,7 @@ sites:
     url: "https://metoree.com/companies/"
     schedule: "0 21 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://metoree.com/terms/"
 
   - site_id: mitsuri
     name: "Mitsuri(ミツリ)"
@@ -3303,7 +3303,7 @@ sites:
     url: "https://app.mitsu-ri.net/pblc/suppliers?_gl=1*wczuq3*_ga*MTg0MTM0NDU5MS4xNzgyNzg2NDg5*_ga_SQCQZHNTCS*czE3ODI3ODY0ODgkbzEkZzEkdDE3ODI3ODgyMTckajMyJGwwJGgw"
     schedule: "0 22 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://help.mitsu-ri.net/help/terms-user"
 
   - site_id: town_life
     name: "タウンライフリフォーム"
@@ -3311,7 +3311,7 @@ sites:
     url: "https://www.town-life.jp/home/main/chatform.php"
     schedule: "20 22 1-7 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.town-life.jp/toppage/terms.html"
 
   - site_id: lifull_home_s
     name: "LIFULL HOME'S 注文住宅(ライフルホームズ)"
@@ -3319,7 +3319,7 @@ sites:
     url: "https://www.homes.co.jp/realtor/"
     schedule: "20 22 1-7 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.homes.co.jp/kiyaku/"
 
   - site_id: hikkoshizamurai
     name: "引越し侍"
@@ -3327,7 +3327,7 @@ sites:
     url: "https://hikkoshizamurai.jp/company/"
     schedule: "20 22 8-14 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://hikkoshizamurai.jp/popup/terms.html"
 
   - site_id: relax_job
     name: "リジョブ"
@@ -3335,7 +3335,7 @@ sites:
     url: "https://relax-job.com/"
     schedule: "0 17 19 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://relax-job.com/info/terms"
 
   - site_id: e_sogi
     name: "いい葬儀"
@@ -3343,7 +3343,7 @@ sites:
     url: "https://www.e-sogi.com/"
     schedule: "20 22 8-14 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.kamakura-net.co.jp/servicepolicy/"
 
   - site_id: osohshiki
     name: "小さなお葬式"
@@ -3359,7 +3359,7 @@ sites:
     url: "https://www.zeiri4.com/firm/search/?FirmSearchForm%5BPrefecture_id%5D=&FirmSearchForm%5BAutonomy_id%5D="
     schedule: "20 23 15-21 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.zeiri4.com/rules/"
 
   - site_id: bengo4
     name: "弁護士ドットコム"
@@ -3367,7 +3367,7 @@ sites:
     url: "https://www.bengo4.com/search/result/"
     schedule: "20 23 22-28 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.bengo4.com/rules/general/"
 
   - site_id: hanayume
     name: "HANAYUME(ハナユメ)"
@@ -3375,7 +3375,7 @@ sites:
     url: "https://hana-yume.net/search/hallList/?sg_hs%5Barea%5D=&sg_hs%5Border%5D=&sg_hs%5BsearchKind%5D="
     schedule: "20 23 22-28 * SUN"
     enabled: true
-    terms_url: ""
+    terms_url: "https://hana-yume.net/pages/rule/"
 
   - site_id: eslove
     name: "エステラブ"
@@ -3399,7 +3399,7 @@ sites:
     url: "https://zexy.net/"
     schedule: null
     enabled: true
-    terms_url: ""
+    terms_url: "https://cdn.p.recruit.co.jp/terms/zxy-t-1003/index.html"
 
   - site_id: baitoru_5
     name: "バイトル関西_工場"
@@ -3407,7 +3407,7 @@ sites:
     url: "https://www.baitoru.com/kansai/jlist/"
     schedule: "0 9 * * 1"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.baitoru.com/about/kiyaku_base.html"
 
   - site_id: sumitec_kanto_2
     name: "リンクスアシスト"
@@ -3415,7 +3415,7 @@ sites:
     url: "https://sumitec-kanto.com/page/1?s"
     schedule: "0 9 * * 1"
     enabled: true
-    terms_url: ""
+    terms_url: "https://sumitec-kanto.com/term"
 
   - site_id: ciic
     name: "CIIC"
@@ -3423,7 +3423,7 @@ sites:
     url: "https://www.ciic.or.jp/"
     schedule: "0 9 24 * 0"
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.ciic.or.jp/ciic/privacy/"
 
   - site_id: hapisumu
     name: "ハピすむ（リフォーム加盟店）"
@@ -3431,7 +3431,7 @@ sites:
     url: "https://hapisumu.jp/"
     schedule: "0 20 13 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://policy.bm-sms.co.jp/consumer/terms/hapisumu-jp"
 
   - site_id: gaiheki_madoguchi
     name: "外壁塗装の窓口"
@@ -3439,7 +3439,7 @@ sites:
     url: "https://gaiheki-madoguchi.com/"
     schedule: null
     enabled: true
-    terms_url: ""
+    terms_url: "https://gaiheki-madoguchi.com/rule"
 
   - site_id: lancers
     name: "サンラーズ"
@@ -3447,4 +3447,4 @@ sites:
     url: "https://www.lancers.jp/"
     schedule: null
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.lancers.jp/help/terms?ref=footer"


### PR DESCRIPTION
## 概要
`sites_URL.xlsx` の資料をもとに、各サイトの利用規約/免責/ポリシーURLを `sites.yml` の `terms_url` に反映しました。

## 内容
- Excelの「登録URL(sites.yml)」列で `sites.yml` の `url` と突き合わせ、「利用規約/免責/ポリシーURL」列を各エントリの `terms_url` に設定
- **396エントリ**を更新（既存値は差し替え、`terms_url` キーが無いエントリは `enabled:` 直後に追加）
- 同一URLが複数エントリに紐づく曖昧ケース（スタンバイ / スタンバイ ナイトワーク、建築計画のお知らせ看板情報【首都圏】/ 同、人材サービス総合 / ハローワーク）は、サイト名一致・消去法で個別に解決

## 確認
- 変更は `terms_url` 行のみ（396挿入 / 313削除）
- YAML再パースで429エントリ正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)