### PR TITLE
feat: sites.yml の各エントリにユニーク番号コメントを付与

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -17,6 +17,7 @@
 
 sites:
 
+#1
   - site_id: inuki_honpo
     name: "居抜き本舗（居抜き・クラブキャバクラ・東京都）"
     module: "realestate.inuki_honpo"
@@ -25,6 +26,7 @@ sites:
     enabled: true
     terms_url: "https://www.inuki-honpo.jp/terms/"
 
+#2
   - site_id: beautyworld_japan_tokyo
     name: "Beautyworld Japan Tokyo"
     module: "beauty.beautyworld_japan_tokyo"
@@ -33,6 +35,7 @@ sites:
     enabled: true
     terms_url: "https://beautyworld-japan.jp.messefrankfurt.com/tokyo/ja/footer/imprint.html"
 
+#3
   - site_id: furugi_meguru
     name: "古着屋巡りマップガイド MEGURU"
     module: "portal.furugi_meguru"
@@ -41,6 +44,7 @@ sites:
     enabled: true
     terms_url: "https://furugi-meguru.com/termsofservice/"
 
+#4
   - site_id: eaidem
     name: "イーアイデム"
     module: "jobs.eaidem"
@@ -49,6 +53,7 @@ sites:
     enabled: true
     terms_url: "https://www.e-aidem.com/contents/info/kiyaku.htm"
 
+#5
   - site_id: yorushoku
     name: "夜職倶楽部" 
     module: "nightlife.yorushoku"
@@ -57,6 +62,7 @@ sites:
     enabled: true
     terms_url: "https://yorushoku.jp/terms-of-service/"
 
+#6
   - site_id: shinq_compass
     name: "鍼灸コンパス"
     module: "medical.shinq_compass"
@@ -65,6 +71,7 @@ sites:
     enabled: true
     terms_url: "https://www.shinq-compass.jp/info/kiyaku"
 
+#7
   - site_id: imitsu_sales_agent
     name: "PRONIアイミツ_営業代行"
     module: "service.imitsu"
@@ -73,6 +80,7 @@ sites:
     enabled: true
     terms_url: "https://imitsu.jp/terms/"
 
+#8
   - site_id: biz_sales_outsourcing
     name: "比較ビズ_営業代行"
     module: "service.biz_sales_outsourcing"
@@ -81,6 +89,7 @@ sites:
     enabled: true
     terms_url: "https://www.biz.ne.jp/help/regulation.html"
 
+#9
   - site_id: reshop-navi
     name: "リショップナビ"
     module: "realestate.reshop_navi"
@@ -89,6 +98,7 @@ sites:
     enabled: true
     terms_url: "https://rehome-navi.com/informations/terms"
 
+#10
   - site_id: shisha-suitai
     name: "シーシャスイタイ"
     module: "nightlife.shisha_suitai"
@@ -97,6 +107,7 @@ sites:
     enabled: true
     terms_url: "https://shisha-suitai.com/service_term"
 
+#11
   - site_id: refonavi
     name: "リフォーム評価ナビ"
     module: "realestate.refonavi"
@@ -105,6 +116,7 @@ sites:
     enabled: true
     terms_url: "https://www.refonavi.or.jp/tos"
 
+#12
   - site_id: nihon_ryoko_kyokai
     name: "日本旅館協会"
     module: "realestate.nihon_ryoko_kyokai"
@@ -113,6 +125,7 @@ sites:
     enabled: true
     terms_url: "https://www.ryokan.or.jp/sitepolicy/"
 
+#13
   - site_id: hairlog
     name: "HAIRLOG"
     module: "beauty.hairlog"
@@ -121,6 +134,7 @@ sites:
     enabled: true
     terms_url: "https://hairlog.jp/terms"
 
+#14
   - site_id: rakuten_beauty
     name: "楽天ビューティ"
     module: "beauty.rakuten_beauty"
@@ -129,6 +143,7 @@ sites:
     enabled: true
     terms_url: "https://beauty.rakuten.co.jp/cnt/terms/"
 
+#15
   - site_id: minimo
     name: "ミニモ"
     module: "beauty.minimo"
@@ -137,6 +152,7 @@ sites:
     enabled: true
     terms_url: "https://minimodel.jp/policy/minimo"
 
+#16
   - site_id: goonet
     name: "グーネット"
     module: "auto.goonet"
@@ -145,6 +161,7 @@ sites:
     enabled: true
     terms_url: "https://www.goo-net.com/info/tos.html"
 
+#17
   - site_id: ii_ie
     name: "いい部屋ネット"
     module: "realestate.ii_ie"
@@ -153,6 +170,7 @@ sites:
     enabled: true
     terms_url: "https://www.eheya.net/contents/terms/"
 
+#18
   - site_id: ielove
     name: "いえらぶ"
     module: "realestate.ielove"
@@ -161,6 +179,7 @@ sites:
     enabled: true
     terms_url: "https://www.ielove.co.jp/rules/"
 
+#19
   - site_id: ju_ren
     name: "充レン"
     module: "service.ju_ren"
@@ -169,6 +188,7 @@ sites:
     enabled: true
     terms_url: "https://ju-ren.jp/terms/"
 
+#20
   - site_id: franchise_web_repo
     name: "フランチャイズWEBリポート"
     module: "agency_franchise.franchise_web_repo"
@@ -177,6 +197,7 @@ sites:
     enabled: true
     terms_url: "https://web-repo.jp/etc/agreement"
 
+#21
   - site_id: yourmystar
     name: "ユアマイスター"
     module: "service.yourmystar"
@@ -185,6 +206,7 @@ sites:
     enabled: true
     terms_url: "https://yourmystar.jp/terms/"
 
+#22
   - site_id: meetsmore
     name: "ミツモア"
     module: "service.meetsmore"
@@ -193,6 +215,7 @@ sites:
     enabled: true
     terms_url: "https://meetsmore.com/policies/terms"
 
+#23
   - site_id: bilax_net
     name: "びらくネット"
     module: "service.bilax_net"
@@ -201,6 +224,7 @@ sites:
     enabled: true
     terms_url: "https://bilax.net/usr_kiyaku.cgi"
 
+#24
   - site_id: dokenchiku
     name: "ドケンチク"
     module: "construction.dokenchiku"
@@ -209,6 +233,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#25
   - site_id: koujishi
     name: "工事士.com"
     module: "construction.koujishi"
@@ -217,6 +242,7 @@ sites:
     enabled: true
     terms_url: "https://koujishi.com/page/rules/"
 
+#26
   - site_id: dairitenfc
     name: "代理店FC"
     module: "agency_franchise.dairitenfc"
@@ -225,6 +251,7 @@ sites:
     enabled: true
     terms_url: "https://dairitenfc.com/rules/index.html"
 
+#27
   - site_id: hakkosha
     name: "白光舎"
     module: "service.hakkosha"
@@ -233,6 +260,7 @@ sites:
     enabled: true
     terms_url: "https://hakkousya.co.jp/privacy/"
 
+#28
   - site_id: hitosara
     name: "ヒトサラ"
     module: "food.hitosara"
@@ -241,6 +269,7 @@ sites:
     enabled: true
     terms_url: "https://usen.media/rules/hitosara/"
 
+#29
   - site_id: doctor_map
     name: "ドクターマップ"
     module: "medical.doctor_map"
@@ -249,6 +278,7 @@ sites:
     enabled: true
     terms_url: "https://www.homemate-research.com/info/rule/"
 
+#30
   - site_id: torabayu
     name: "とらばーゆ"
     module: "jobs.torabayu"
@@ -257,6 +287,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/trn-t-1002/index.html"
 
+#31
   - site_id: million_job
     name: "ミリオンジョブ"
     module: "jobs.million_job"
@@ -265,6 +296,7 @@ sites:
     enabled: true
     terms_url: "https://www.million-job.com/terms/"
 
+#32
   - site_id: refjob
     name: "リフラクジョブ"
     module: "jobs.refjob"
@@ -273,6 +305,7 @@ sites:
     enabled: true
     terms_url: "https://refjob.jp/terms"
 
+#33
   - site_id: tainyu_chocolat
     name: "体入ショコラ"
     module: "jobs.tainyu_chocolat"
@@ -281,6 +314,7 @@ sites:
     enabled: true
     terms_url: "https://chocolat.work/terms/"
 
+#34
   - site_id: tainyu_macaron
     name: "体入マカロン"
     module: "jobs.tainyu_macaron"
@@ -289,6 +323,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#35
   - site_id: tadaoka_shoko
     name: "忠岡町商工会"
     module: "government.tadaoka_shoko"
@@ -297,6 +332,7 @@ sites:
     enabled: true
     terms_url: "https://www.tadaoka.or.jp/kojinjyouhou.html"
 
+#36
   - site_id: bepro
     name: "美プロ"
     module: "jobs.bepro"
@@ -305,6 +341,7 @@ sites:
     enabled: true
     terms_url: "https://www.kenkou-job.com/about/terms.html"
 
+#37
   - site_id: yakukyari
     name: "薬キャリ（法人）"
     module: "jobs.yakukyari"
@@ -313,6 +350,7 @@ sites:
     enabled: true
     terms_url: "https://pcareer.m3.com/shokubanavi/terms_of_service"
 
+#38
   - site_id: yakukyari_office
     name: "薬キャリ（事業所）"
     module: "jobs.yakukyari_office"
@@ -321,6 +359,7 @@ sites:
     enabled: true
     terms_url: "https://pcareer.m3.com/shokubanavi/terms_of_service"
 
+#39
   - site_id: kaiten_heiten
     name: "開店閉店ドットコム"
     module: "portal.kaiten_heiten"
@@ -329,6 +368,7 @@ sites:
     enabled: true
     terms_url: "https://kaiten-heiten.com/index.php/privacy-policy/"
 
+#40
   - site_id: inshokuten_job
     name: "求人飲食店ドットコム"
     module: "food.inshokuten_job"
@@ -337,6 +377,7 @@ sites:
     enabled: true
     terms_url: "https://job.inshokuten.com/term"
 
+#41
   - site_id: paypaygourmet
     name: "PayPayグルメ"
     module: "food.paypaygourmet"
@@ -345,6 +386,7 @@ sites:
     enabled: true
     terms_url: "https://www.lycorp.co.jp/ja/company/terms/"
 
+#42
   - site_id: suumo
     name: "SUUMO不動産会社"
     module: "realestate.suumo"
@@ -353,6 +395,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/suu-t-1003/index.html"
 
+#43
   - site_id: suumo_buy
     name: "SUUMO新築・中古物件"
     module: "realestate.suumo_buy"
@@ -361,6 +404,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/suu-t-1003/index.html"
 
+#44
   - site_id: suumo_guide
     name: "SUUMO不動産会社ガイド"
     module: "realestate.suumo_guide"
@@ -369,6 +413,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/suu-t-1003/index.html"
 
+#45
   - site_id: yameshi_shokokai
     name: "八女市商工会"
     module: "government.yameshi_shokokai"
@@ -377,6 +422,7 @@ sites:
     enabled: true
     terms_url: "https://www.yameshi-shokokai.jp/pp/"
 
+#46
   - site_id: ogori_shokokai
     name: "小郡市商工会"
     module: "government.ogori_shokokai"
@@ -385,6 +431,7 @@ sites:
     enabled: true
     terms_url: "https://ogori-shoukoukai.com/privacy/"
 
+#47
   - site_id: kawachinagano_shokokai
     name: "河内長野市商工会"
     module: "government.kawachinagano_shokokai"
@@ -393,6 +440,7 @@ sites:
     enabled: true
     terms_url: "http://www.ksci.or.jp/privacy.html"
 
+#48
   - site_id: ai_med
     name: "アイメッド"
     module: "medical.ai_med"
@@ -401,6 +449,7 @@ sites:
     enabled: true
     terms_url: "https://ai-med.jp/clause"
 
+#49
   - site_id: challenge_plus
     name: "チャレンジプラス"
     module: "agency_franchise.challenge_plus"
@@ -409,6 +458,7 @@ sites:
     enabled: true
     terms_url: "https://www.challenge-plus.jp/ctsite/"
 
+#50
   - site_id: entre_net
     name: "アントレ"
     module: "jobs.entre_net"
@@ -417,6 +467,7 @@ sites:
     enabled: true
     terms_url: "https://entrenet.jp/others/kiyaku/"
 
+#51
   - site_id: gappori
     name: "ガッポリ"
     module: "jobs.gappori"
@@ -425,6 +476,7 @@ sites:
     enabled: true
     terms_url: "https://gappori.jp/a_site_rule/"
 
+#52
   - site_id: hanacupid
     name: "花キューピット"
     module: "service.hanacupid"
@@ -433,6 +485,7 @@ sites:
     enabled: true
     terms_url: "https://www.i879.com/about/"
 
+#53
   - site_id: dan_work
     name: "男ワーク"
     module: "jobs.dan_work"
@@ -441,6 +494,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#54
   - site_id: hamanight
     name: "ハマんナイト"
     module: "jobs.hamanight"
@@ -449,6 +503,7 @@ sites:
     enabled: true
     terms_url: "http://www.hamanight.com/tos.html"
 
+#55
   - site_id: tainew_otoko
     name: "メンズ体入"
     module: "jobs.tainew_otoko"
@@ -457,6 +512,7 @@ sites:
     enabled: true
     terms_url: "https://tainew-otoko.com/menu/terms/"
 
+#56
   - site_id: epark_dental
     name: "EPARK歯科"
     module: "medical.epark_dental"
@@ -465,6 +521,7 @@ sites:
     enabled: true
     terms_url: "https://haisha-yoyaku.jp/terms.html"
 
+#57
   - site_id: jobcon_driver
     name: "ジョブコンプラスD"
     module: "jobs.jobcon_driver"
@@ -473,6 +530,7 @@ sites:
     enabled: true
     terms_url: "https://job-con.jp/policy"
 
+#58
   - site_id: jobcon_security
     name: "ジョブコンプラスS"
     module: "jobs.jobcon_security"
@@ -481,6 +539,7 @@ sites:
     enabled: true
     terms_url: "https://job-con.jp/policy"
 
+#59
   - site_id: job_chocolat
     name: "ジョブショコラ"
     module: "jobs.job_chocolat"
@@ -489,6 +548,7 @@ sites:
     enabled: true
     terms_url: "https://job-chocolat.jp/terms/"
 
+#60
   - site_id: doraever
     name: "ドラEVER"
     module: "jobs.doraever"
@@ -497,6 +557,7 @@ sites:
     enabled: true
     terms_url: "https://doraever.jp/terms"
 
+#61
   - site_id: jwarm
     name: "ジェイウォーム"
     module: "jobs.jwarm"
@@ -505,6 +566,7 @@ sites:
     enabled: true
     terms_url: "https://www.jwarm.net/rule.html"
 
+#62
   - site_id: kyujin_journal_net
     name: "求人ジャーナルネット"
     module: "jobs.kyujin_journal_net"
@@ -513,6 +575,7 @@ sites:
     enabled: true
     terms_url: "https://www.job-j.net/static/rules/"
 
+#63
   - site_id: baitoru
     name: "バイトル"
     module: "jobs.baitoru"
@@ -521,6 +584,7 @@ sites:
     enabled: true
     terms_url: "https://www.baitoru.com/about/kiyaku_base.html"
 
+#64
   - site_id: townwork
     name: "タウンワーク"
     module: "jobs.townwork"
@@ -529,6 +593,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/twn-t-1005/index.html"
 
+#65
   - site_id: rikunabi_next_syataku
     name: "リクナビNEXT社宅"
     module: "jobs.rikunabi_next_syataku"
@@ -537,6 +602,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/rnn-t-1001/index.html"
 
+#66
   - site_id: rikunabi_next_syayosha
     name: "リクナビNEXT社用車"
     module: "jobs.rikunabi_next_syayosha"
@@ -545,6 +611,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/rnn-t-1001/index.html"
 
+#67
   - site_id: caloo
     name: "Caloo病院検索"
     module: "medical.caloo"
@@ -553,6 +620,7 @@ sites:
     enabled: true
     terms_url: "https://caloo.jp/terms/"
 
+#68
   - site_id: gaten_job
     name: "ガテン系仕事ナビ"
     module: "jobs.gaten_job"
@@ -561,6 +629,7 @@ sites:
     enabled: true
     terms_url: "https://gaten-job.com/immunity"
 
+#69
   - site_id: jobpost
     name: "ジョブポスト"
     module: "jobs.jobpost"
@@ -569,6 +638,7 @@ sites:
     enabled: true
     terms_url: "https://jobpost.jp/terms"
 
+#70
   - site_id: trck_job
     name: "トラッカーズジョブ"
     module: "jobs.trck_job"
@@ -577,6 +647,7 @@ sites:
     enabled: true
     terms_url: "https://azoop.co.jp/privacy_policy"
 
+#71
   - site_id: barberin
     name: "バーバリン"
     module: "beauty.barberin"
@@ -585,6 +656,7 @@ sites:
     enabled: true
     terms_url: "https://barberin.jp/condition/"
 
+#72
   - site_id: fc_kamei
     name: "フランチャイズ加盟募集"
     module: "agency_franchise.fc_kamei"
@@ -593,6 +665,7 @@ sites:
     enabled: true
     terms_url: "https://fc-kamei.net/terms"
 
+#73
   - site_id: benrishi_navi
     name: "弁理士ナビ"
     module: "portal.benrishi_navi"
@@ -601,6 +674,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#74
   - site_id: prtimes
     name: "PRTIMES"
     module: "corporate.prtimes"
@@ -609,6 +683,7 @@ sites:
     enabled: true
     terms_url: "https://prtimes.jp/main/html/kiyaku"
 
+#75
   - site_id: kessan_kokoku
     name: "決算公告（catr.jp）"
     module: "corporate.kessan_kokoku"
@@ -617,6 +692,7 @@ sites:
     enabled: true
     terms_url: "https://catr.jp/about"
 
+#76
   - site_id: host_para
     name: "ホスパラ"
     module: "nightlife.host_para"
@@ -625,6 +701,7 @@ sites:
     enabled: true
     terms_url: "https://host-paradise.jp/policy/"
 
+#77
   - site_id: mynavi_tenshoku
     name: "マイナビ転職"
     module: "jobs.mynavi_tenshoku"
@@ -633,6 +710,7 @@ sites:
     enabled: true
     terms_url: "https://tenshoku.mynavi.jp/rules/member/"
 
+#78
   - site_id: en_tenshoku
     name: "エン転職"
     module: "jobs.en_tenshoku"
@@ -641,6 +719,7 @@ sites:
     enabled: true
     terms_url: "https://employment.en-japan.com/info/membership/"
 
+#79
   - site_id: kyujin_box_tokutei
     name: "求人ボックス（特定技能の仕事）"
     module: "jobs.kyujin_box_tokutei"
@@ -649,6 +728,7 @@ sites:
     enabled: true
     terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
+#80
   - site_id: kkhashi
     name: "カケハシ"
     module: "agency_franchise.kkhashi"
@@ -657,6 +737,7 @@ sites:
     enabled: true
     terms_url: "https://www.kakehashi.life/support-site-terms"
 
+#81
   - site_id: bahn_rep
     name: "バーン代理店"
     module: "agency_franchise.bahn_rep"
@@ -665,6 +746,7 @@ sites:
     enabled: true
     terms_url: "https://phst.jp/burn_studio/front/page/index.html?page_type=rule&page_path=index"
 
+#82
   - site_id: kyujinbox
     name: "求人ボックス（携帯販売・通信系）"
     module: "jobs.kyujinbox"
@@ -673,6 +755,7 @@ sites:
     enabled: true
     terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
+#83
   - site_id: b_seeds
     name: "Bシーズ"
     module: "agency_franchise.b_seeds"
@@ -681,6 +764,7 @@ sites:
     enabled: true
     terms_url: "https://b-seeds.com/kiyaku/"
 
+#84
   - site_id: mlit_kensetsu
     name: "国交省建設業者検索_建設業"
     module: "construction.mlit_kensetsu"
@@ -689,6 +773,7 @@ sites:
     enabled: true    
     terms_url: "https://www.digital.go.jp/resources/open_data/public_data_license_v1.0"
 
+#85
   - site_id: mlit_takken
     name: "建設業者・宅建業者等企業情報検索システム【賃貸住宅管理業者】"
     module: "realestate.mlit_takken"
@@ -697,6 +782,7 @@ sites:
     enabled: true   
     terms_url: "https://www.digital.go.jp/resources/open_data/public_data_license_v1.0"
 
+#86
   - site_id: aupay
     name: "aupay"
     module: "service.aupay"
@@ -705,6 +791,7 @@ sites:
     enabled: true
     terms_url: "https://wallet.auone.jp/contents/lp/terms/aupayall.html"
 
+#87
   - site_id: tabelog
     name: "食べログ"
     module: "food.tabelog"
@@ -713,6 +800,7 @@ sites:
     enabled: true
     terms_url: "https://tabelog.com/help/rules/"
 
+#88
   - site_id: foodslabo
     name: "foodslabo"
     module: "food.foodslabo"
@@ -721,6 +809,7 @@ sites:
     enabled: true
     terms_url: "https://foods-labo.com/terms"
 
+#89
   - site_id: ivry
     name: "ivry"
     module: "corporate.ivry"
@@ -729,6 +818,7 @@ sites:
     enabled: true
     terms_url: "https://ivry.jp/terms/"
 
+#90
   - site_id: kocchake
     name: "kocchake"
     module: "jobs.kocchake"
@@ -737,6 +827,7 @@ sites:
     enabled: true
     terms_url: "https://kocchake.com/pages/privacy-policy"
 
+#91
   - site_id: rakuten_beauty_2
     name: "rakuten_beauty"
     module: "beauty.rakuten_beauty_2"
@@ -745,6 +836,7 @@ sites:
     enabled: true
     terms_url: "https://beauty.rakuten.co.jp/cnt/terms/"
 
+#92
   - site_id: savor_japan
     name: "savor_japan"
     module: "food.savor_japan"
@@ -753,6 +845,7 @@ sites:
     enabled: true
     terms_url: "https://savorjapan.com/terms"
 
+#93
   - site_id: emily_job
     name: "体入エミリー"
     module: "nightlife.emily_job"
@@ -761,6 +854,7 @@ sites:
     enabled: true
     terms_url: "https://emily-job.jp/policy/"
 
+#94
   - site_id: suumo_2
     name: "suumo【不動産会社ガイド】"
     module: "realestate.suumo_2"
@@ -769,6 +863,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/suu-t-1003/index.html"
 
+#95
   - site_id: agri_navi
     name: "あぐりナビ"
     module: "jobs.agri_navi"
@@ -777,6 +872,7 @@ sites:
     enabled: true
     terms_url: "https://www.agri-navi.com/membership_agreement"
 
+#96
   - site_id: o_kuruma
     name: "おくるまドットコム"
     module: "auto.o_kuruma"
@@ -785,6 +881,7 @@ sites:
     enabled: true
     terms_url: "https://www.o-kuruma.com/html/policy.html"
 
+#97
   - site_id: curama
     name: "くらしのマーケット"
     module: "service.curama"
@@ -793,6 +890,7 @@ sites:
     enabled: true
     terms_url: "https://curama.jp/terms/"
 
+#98
   - site_id: gnavi
     name: "ぐるなび"
     module: "food.gnavi"
@@ -801,6 +899,7 @@ sites:
     enabled: true
     terms_url: "https://corporate.gnavi.co.jp/agreement/"
 
+#99
   - site_id: mypl
     name: "まいぷれ"
     module: "portal.mypl"
@@ -809,6 +908,7 @@ sites:
     enabled: true
     terms_url: "https://mypl.net/use_policy/"
 
+#100
   - site_id: moe_navi
     name: "もえなび"
     module: "nightlife.moe_navi"
@@ -817,6 +917,7 @@ sites:
     enabled: true
     terms_url: "https://moe-life.jp/rules/"
 
+#101
   - site_id: ai_med_2
     name: "アイメッド"
     module: "medical.ai_med_2"
@@ -825,6 +926,7 @@ sites:
     enabled: true
     terms_url: "https://ai-med.jp/clause"
 
+#102
   - site_id: asoview
     name: "アソビュー"
     module: "portal.asoview"
@@ -833,6 +935,7 @@ sites:
     enabled: true
     terms_url: "https://www.asoview.com/info/terms/"
 
+#103
   - site_id: up_stage
     name: "アップステージ"
     module: "jobs.up_stage"
@@ -841,6 +944,7 @@ sites:
     enabled: true
     terms_url: "https://www.up-stage.info/contents-regulation/"
 
+#104
   - site_id: baito
     name: "アルバイトナイツ"
     module: "nightlife.baito"
@@ -849,6 +953,7 @@ sites:
     enabled: true
     terms_url: "https://baito.nights.fun/help/rules/"
 
+#105
   - site_id: mono
     name: "イプロス"
     module: "corporate.mono"
@@ -857,6 +962,7 @@ sites:
     enabled: true
     terms_url: "https://my.ipros.com/legal/"
 
+#106
   - site_id: carcon
     name: "カーコンビニ俱楽部"
     module: "auto.carcon"
@@ -865,6 +971,7 @@ sites:
     enabled: true
     terms_url: "https://www.carcon.co.jp/privacy/"
 
+#107
   - site_id: carsensor
     name: "カーセンサー"
     module: "auto.carsensor"
@@ -873,6 +980,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/car-t-1008/index.html"
 
+#108
   - site_id: cabaito
     name: "キャバイト求人"
     module: "nightlife.cabaito"
@@ -881,6 +989,7 @@ sites:
     enabled: true
     terms_url: "https://www.cabaito.jp/rule.html"
 
+#109
   - site_id: genbars
     name: "ゲンバーズ"
     module: "jobs.genbars"
@@ -889,6 +998,7 @@ sites:
     enabled: true
     terms_url: "https://genbars.jp/contents-regulation/"
 
+#110
   - site_id: webjobpark
     name: "ジョブこねっと"
     module: "jobs.webjobpark"
@@ -897,6 +1007,7 @@ sites:
     enabled: true
     terms_url: "https://webjobpark.kyoto.jp/rules/"
 
+#111
   - site_id: job_chocolat_2
     name: "ジョブショコラ"
     module: "jobs.job_chocolat_2"
@@ -905,6 +1016,7 @@ sites:
     enabled: true
     terms_url: "https://job-chocolat.jp/terms/"
 
+#112
   - site_id: navi
     name: "ジョブナビ愛知"
     module: "jobs.navi"
@@ -913,6 +1025,7 @@ sites:
     enabled: true
     terms_url: "https://www.navi.j-kin.com/index.php?app_controller=page&p=membership"
 
+#113
   - site_id: concierge
     name: "ダイエットコンシェルジュ"
     module: "service.concierge"
@@ -921,6 +1034,7 @@ sites:
     enabled: true
     terms_url: "https://concierge.diet/service/"
 
+#114
   - site_id: moppy_baito
     name: "ディスカバイト"
     module: "jobs.moppy_baito"
@@ -929,6 +1043,7 @@ sites:
     enabled: true
     terms_url: "https://moppy-baito.com/kiyaku/"
 
+#115
   - site_id: trimtrim_salons
     name: "トリムトリム【サロン】"
     module: "beauty.trimtrim_salons"
@@ -937,6 +1052,7 @@ sites:
     enabled: true
     terms_url: "https://trimtrim.jp/tos"
 
+#116
   - site_id: trimtrim_hotels
     name: "トリムトリム【ホテル】"
     module: "service.trimtrim_hotels"
@@ -945,6 +1061,7 @@ sites:
     enabled: true
     terms_url: "https://trimtrim.jp/tos"
 
+#117
   - site_id: nuri_kae
     name: "ヌリカエ"
     module: "construction.nuri_kae"
@@ -953,6 +1070,7 @@ sites:
     enabled: true
     terms_url: "https://www.nuri-kae.jp/rule"
 
+#118
   - site_id: hellowork
     name: "ハローワーク"
     module: "jobs.hellowork"
@@ -961,6 +1079,7 @@ sites:
     enabled: true
     terms_url: "https://www.hellowork.mhlw.go.jp/info/terms.html"
 
+#119
   - site_id: hellowork_shinnkikyuujin
     name: "ハローワーク（新規求人）"
     module: "jobs.hellowork_shinnkikyuujin"
@@ -969,6 +1088,7 @@ sites:
     enabled: true
     terms_url: "https://www.hellowork.mhlw.go.jp/info/terms.html"
 
+#120
   - site_id: baitona_joshi
     name: "バイトな女子"
     module: "jobs.baitona_joshi"
@@ -977,6 +1097,7 @@ sites:
     enabled: true
     terms_url: "https://baitona-joshi.jp/terms/"
 
+#121
   - site_id: com
     name: "バーバーナビ.com"
     module: "beauty.com"
@@ -985,6 +1106,7 @@ sites:
     enabled: true
     terms_url: "https://barbernavi.com/privacy-policy/"
 
+#122
   - site_id: doda
     name: "doda"
     module: "jobs.doda"
@@ -993,6 +1115,7 @@ sites:
     enabled: true
     terms_url: "https://doda.jp/material/kiyaku/001.html"
 
+#123
   - site_id: mynavi2027
     name: "マイナビ2027"
     module: "jobs.mynavi2027"
@@ -1001,6 +1124,7 @@ sites:
     enabled: true
     terms_url: "https://job.mynavi.jp/sitepolicy/index.html"
 
+#124
   - site_id: baitoru_next
     name: "バイトルNEXT"
     module: "jobs.baitoru_next"
@@ -1009,6 +1133,7 @@ sites:
     enabled: true
     terms_url: "https://www.baitoru.com/about/kiyaku.html"
 
+#125
   - site_id: biz_all
     name: "比較ビズ（全業種）"
     module: "corporate.biz_all"
@@ -1017,6 +1142,7 @@ sites:
     enabled: true
     terms_url: "https://www.biz.ne.jp/help/regulation.html"
 
+#126
   - site_id: activityjapan
     name: "アクティビティジャパン"
     module: "service.activityjapan"
@@ -1025,6 +1151,7 @@ sites:
     enabled: true
     terms_url: "https://activityjapan.com/accept/use/policy"
 
+#127
   - site_id: qlife
     name: "QLife"
     module: "service.qlife"
@@ -1033,6 +1160,7 @@ sites:
     enabled: true
     terms_url: "https://www.qlife.co.jp/terms"
 
+#128
   - site_id: kurashinomarket
     name: "くらしのマーケット（カテゴリ）"
     module: "service.kurashinomarket"
@@ -1041,6 +1169,7 @@ sites:
     enabled: true
     terms_url: "https://curama.jp/terms/"
 
+#129
   - site_id: kaago
     name: "Kaago"
     module: "portal.kaago"
@@ -1049,6 +1178,7 @@ sites:
     enabled: true
     terms_url: "https://kaago.com/static/tos/"
 
+#130
   - site_id: lixil_reformshop
     name: "LIXILリフォームショップ"
     module: "realestate.lixil_reformshop"
@@ -1057,6 +1187,7 @@ sites:
     enabled: true
     terms_url: "https://www.lixil-reformshop.jp/termsofuse/"
 
+#131
   - site_id: ozmall_hairsalon
     name: "オズモール（ヘアサロン）"
     module: "beauty.ozmall"
@@ -1065,6 +1196,7 @@ sites:
     enabled: true
     terms_url: "https://www.ozmall.co.jp/introduction/14118/"
 
+#132
   - site_id: pola
     name: "POLA"
     module: "beauty.pola"
@@ -1073,6 +1205,7 @@ sites:
     enabled: true
     terms_url: "https://www.pola.co.jp/privacy/rule/"
 
+#133
   - site_id: cookbiz
     name: "クックビズ"
     module: "jobs.cookbiz"
@@ -1081,6 +1214,7 @@ sites:
     enabled: true
     terms_url: "https://cookbiz.co.jp/terms"
 
+#134
   - site_id: rejob
     name: "Rejob"
     module: "corporate.rejob"
@@ -1089,6 +1223,7 @@ sites:
     enabled: true
     terms_url: "https://relax-job.com/info/terms"
 
+#135
   - site_id: domonet
     name: "ドモネット"
     module: "jobs.domonet"
@@ -1097,6 +1232,7 @@ sites:
     enabled: true
     terms_url: "https://domonet.jp/info/agreement"
 
+#136
   - site_id: anny
     name: "Anny"
     module: "food.Anny_scrape"
@@ -1105,6 +1241,7 @@ sites:
     enabled: true
     terms_url: "https://oiwai.anny.gift/terms-of-use"
 
+#137
   - site_id: cafe397
     name: "Cafe397"
     module: "food.cafe397"
@@ -1113,6 +1250,7 @@ sites:
     enabled: true
     terms_url: "https://397.cafe/page.php?page=rule"
 
+#138
   - site_id: japan_food_guide
     name: "Japan Food Guide"
     module: "food.japan_food_guide"
@@ -1121,6 +1259,7 @@ sites:
     enabled: true
     terms_url: "https://japan-food.guide/terms_of_use"
 
+#139
   - site_id: ozmall_restaurant
     name: "オズモール（レストラン）"
     module: "food.ozmall_2"
@@ -1129,6 +1268,7 @@ sites:
     enabled: true
     terms_url: "https://www.ozmall.co.jp/introduction/14118/"
 
+#140
   - site_id: beautypark
     name: "Beauty Park"
     module: "medical.beautypark"
@@ -1137,6 +1277,7 @@ sites:
     enabled: true
     terms_url: "https://www.beauty-park.jp/pages/use_rule/"
 
+#141
   - site_id: hospita
     name: "HOSPITA"
     module: "medical.HOSPITA_scrape"
@@ -1145,6 +1286,7 @@ sites:
     enabled: true
     terms_url: "https://www.hospita.jp/about/terms-of-use"
 
+#142
   - site_id: caferun
     name: "カフェるん"
     module: "portal.caferun"
@@ -1153,6 +1295,7 @@ sites:
     enabled: true
     terms_url: "https://caferun.jp/terms/"
 
+#143
   - site_id: dartslive
     name: "DARTSLIVE"
     module: "portal.dartslive"
@@ -1161,6 +1304,7 @@ sites:
     enabled: true
     terms_url: "https://www.dartslive.com/jp/terms/"
 
+#144
   - site_id: fitmap
     name: "Fit Map"
     module: "portal.fitmap"
@@ -1169,6 +1313,7 @@ sites:
     enabled: true
     terms_url: "https://fitmap.jp/agree/"
 
+#145
   - site_id: imitsu_pr
     name: "PRONIアイミツ_PR"
     module: "portal.imitsu_pr"
@@ -1177,6 +1322,7 @@ sites:
     enabled: true
     terms_url: "https://imitsu.jp/terms/"
 
+#146
   - site_id: pepperlikes
     name: "PepperLikes"
     module: "portal.pepperlikes"
@@ -1185,6 +1331,7 @@ sites:
     enabled: true
     terms_url: "https://www.pepperlikes.com/terms-and-conditions"
 
+#147
   - site_id: manabi_senmon
     name: "マナビ（専門）"
     module: "service.manabi_senmon"
@@ -1193,6 +1340,7 @@ sites:
     enabled: true
     terms_url: "https://manabi.benesse.ne.jp/doc/rules/rules.html"
 
+#148
   - site_id: biztel
     name: "BIZTEL"
     module: "corporate.biztel"
@@ -1201,6 +1349,7 @@ sites:
     enabled: true
     terms_url: "https://biztel.jp/agreement/"
 
+#149
   - site_id: domo
     name: "Domo"
     module: "corporate.domo"
@@ -1209,6 +1358,7 @@ sites:
     enabled: true
     terms_url: "https://www.domo.com/jp/company/service-terms"
 
+#150
   - site_id: hnavi
     name: "発注ナビ"
     module: "corporate.hnavi"
@@ -1217,6 +1367,7 @@ sites:
     enabled: true
     terms_url: "https://hnavi.co.jp/tos/"
 
+#151
   - site_id: j_lic
     name: "J-LIC"
     module: "corporate.j_lic"
@@ -1225,6 +1376,7 @@ sites:
     enabled: true
     terms_url: "https://j-lic.com/terms"
 
+#152
   - site_id: kepple
     name: "KEPPLE"
     module: "corporate.kepple"
@@ -1233,6 +1385,7 @@ sites:
     enabled: true
     terms_url: "https://kepple.co.jp/term"
 
+#153
   - site_id: kyozon
     name: "kyozon"
     module: "corporate.kyozon"
@@ -1241,6 +1394,7 @@ sites:
     enabled: true
     terms_url: "https://kyozon.net/company/terms-of-use/"
 
+#154
   - site_id: pitta_lab
     name: "ピッタラボ"
     module: "corporate.pitta_lab"
@@ -1249,6 +1403,7 @@ sites:
     enabled: true
     terms_url: "https://pitta-lab.com/termsOfUse"
 
+#155
   - site_id: nihon_souko_kyokai
     name: "日本倉庫協会"
     module: "corporate.nihon_souko_kyokai"
@@ -1257,6 +1412,7 @@ sites:
     enabled: true
     terms_url: "https://www.nissokyo.or.jp/privacypolicy/"
 
+#156
   - site_id: nihon_reizousouko_kyokai
     name: "日本冷蔵倉庫協会"
     module: "corporate.nihon_reizousouko_kyokai"
@@ -1265,6 +1421,7 @@ sites:
     enabled: true
     terms_url: "https://www.jarw.or.jp/privacy"
 
+#157
   - site_id: j_reit
     name: "J-REIT"
     module: "corporate.j_reit"
@@ -1273,6 +1430,7 @@ sites:
     enabled: true
     terms_url: "https://j-reit.jp/notice.html"
 
+#158
   - site_id: dairitenhonpo
     name: "代理店募集本舗"
     module: "agency_franchise.dairitenhonpo"
@@ -1281,6 +1439,7 @@ sites:
     enabled: true
     terms_url: "https://dairitenboshu.com/pages/terms"
 
+#159
   - site_id: panasonic_cycle
     name: "Panasonic Cycle"
     module: "agency_franchise.panasonic_cycle"
@@ -1289,6 +1448,7 @@ sites:
     enabled: true
     terms_url: "https://holdings.panasonic/jp/terms-of-use.html"
 
+#160
   - site_id: sumitec_kanto
     name: "住まいテック関東"
     module: "construction.sumitec_kanto"
@@ -1297,6 +1457,7 @@ sites:
     enabled: true
     terms_url: "https://sumitec-kanto.com/term/"
 
+#161
   - site_id: hiroshima_hitec
     name: "広島市ハイテクプラザ"
     module: "government.hiroshima_hitec"
@@ -1305,6 +1466,7 @@ sites:
     enabled: true
     terms_url: "https://www.itc.city.hiroshima.jp/privacy.html"
 
+#162
   - site_id: sanpai_kun
     name: "さんぱいくん"
     module: "government.sanpai_kun"
@@ -1313,6 +1475,7 @@ sites:
     enabled: true
     terms_url: "https://www.sanpainet.or.jp/content.php?id=2"
 
+#163
   - site_id: alzo
     name: "アルゾ"
     module: "jobs.alzo"
@@ -1321,6 +1484,7 @@ sites:
     enabled: true
     terms_url: "https://www.alzoweb.jp/?act=kiyaku"
 
+#164
   - site_id: anokono_ehime
     name: "あの子のエヒメ"
     module: "jobs.AnokonoEhime_scrape"
@@ -1329,6 +1493,7 @@ sites:
     enabled: true
     terms_url: "https://ano-kono.ehime.jp/st/terms/"
 
+#165
   - site_id: bejob_navi
     name: "BEJOBナビ"
     module: "jobs.bejob_navi"
@@ -1337,6 +1502,7 @@ sites:
     enabled: true
     terms_url: "https://www.bejob-navi.jp/contract.php"
 
+#166
   - site_id: ishikawa_jobnavi
     name: "石川ジョブナビ"
     module: "jobs.ishikawa_jobnavi"
@@ -1345,6 +1511,7 @@ sites:
     enabled: true
     terms_url: "https://jobnavi-i.jp/terms/"
 
+#167
   - site_id: jinzai_hellowork_syokugyo_syoukai
     name: "人材サービス総合【職業紹介】"
     module: "jobs.jinzai_hellowork_syokugyo_syoukai"
@@ -1353,6 +1520,7 @@ sites:
     enabled: true
     terms_url: "https://jinzai.hellowork.mhlw.go.jp/icb_data/StaticContents/GICB190020.html"
 
+#168
   - site_id: kyujin_box_ginoujissyuu
     name: "求人ボックス（技能実習の仕事）"
     module: "jobs.kyujin_box_ginoujissyuu"
@@ -1361,6 +1529,7 @@ sites:
     enabled: true
     terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
+#169
   - site_id: vinty
     name: "VINTY"
     module: "vinty"
@@ -1369,6 +1538,7 @@ sites:
     enabled: true
     terms_url: "https://www.vinty.jp/terms"
 
+#170
   - site_id: guppy
     name: "GUPPY"
     module: "jobs.guppy"
@@ -1377,6 +1547,7 @@ sites:
     enabled: true
     terms_url: "https://www.guppy.jp/terms"
 
+#171
   - site_id: hikariweb_search
     name: "ひかりWeb NTT東日本特約店・販売委託店"
     module: "agency_franchise.hikariweb_search"
@@ -1385,6 +1556,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#172
   - site_id: hikariweb_cancell
     name: "ひかりWeb NTT東日本解約特約店・販売委託店"
     module: "agency_franchise.hikariweb_cancell"
@@ -1393,6 +1565,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#173
   - site_id: nightstyle
     name: "ナイトスタイル"
     module: "nightlife.nightstyle"
@@ -1401,6 +1574,7 @@ sites:
     enabled: true
     terms_url: "https://nightstyle.jp/terms/"
 
+#174
   - site_id: baitoru_nightwork
     name: "バイトル（ナイトワーク系）"
     module: "jobs.baitoru_nightwork"
@@ -1409,6 +1583,7 @@ sites:
     enabled: true
     terms_url: "https://www.baitoru.com/about/kiyaku_base.html"
 
+#175
   - site_id: epark_hotel
     name: "EPARKホテル・宿泊"
     module: "portal.epark_hotel"
@@ -1417,6 +1592,7 @@ sites:
     enabled: true
     terms_url: "https://terms.epark.jp/use/"
 
+#176
   - site_id: dummy
     name: "ダミー"
     module: "test.dummy"
@@ -1425,6 +1601,7 @@ sites:
     enabled: true
     terms_url: ""
 
+#177
   - site_id: hosytoru
     name: "ホストル"
     module: "nightlife.hosytoru"
@@ -1433,6 +1610,7 @@ sites:
     enabled: true
     terms_url: "https://hostle.jp/guide/"
 
+#178
   - site_id: ntt_west_hanbaiten
     name: "NTT西日本特約店・販売委託店一覧"
     module: "government.ntt_west_hanbaiten"
@@ -1441,6 +1619,7 @@ sites:
     enabled: true
     terms_url: "https://www.ntt-west.co.jp/share/privacy.html"
 
+#179
   - site_id: jinzai_service
     name: "人材サービス総合サイト（職業紹介事業）"
     module: "government.jinzai_service"
@@ -1449,6 +1628,7 @@ sites:
     enabled: true
     terms_url: "https://jinzai.hellowork.mhlw.go.jp/JinzaiWeb/"
 
+#180
   - site_id: casmoo
     name: "ウィリスト"
     module: "nightlife.casmoo"
@@ -1457,6 +1637,7 @@ sites:
     enabled: true
     terms_url: "https://casmoo.jp/rule/"
 
+#181
   - site_id: bizresearch
     name: "ビズリサーチ"
     module: "agency_franchise.bizresearch"
@@ -1465,6 +1646,7 @@ sites:
     enabled: true
     terms_url: "https://www.bizreach.jp/pages/service/rules/"
 
+#182
   - site_id: tokyo_bm_recruit
     name: "ビルメン"
     module: "jobs.tokyo_bm_recruit"
@@ -1473,6 +1655,7 @@ sites:
     enabled: true
     terms_url: "https://www.j-bma.or.jp/site-policy/"
 
+#183
   - site_id: housing_bazar
     name: "ハウジングバザール"
     module: "construction.housing_bazar"
@@ -1481,6 +1664,7 @@ sites:
     enabled: true
     terms_url: "https://www.housingbazar.jp/tou/"
 
+#184
   - site_id: girlsbaito
     name: "ガールズバイト"
     module: "portal.GirlsBaito_scrape"
@@ -1489,6 +1673,7 @@ sites:
     enabled: true
     terms_url: "https://girlsbaito.jp/kanto/agreement"
 
+#185
   - site_id: gb-walker
     name: "ガールズバーウォーカー"
     module: "portal.GirlsbarWalker_scrape"
@@ -1497,6 +1682,7 @@ sites:
     enabled: true
     terms_url: "https://www.gb-walker.jp/guideline/"
 
+#186
   - site_id: lounge-tapioka
     name: "ラウンジタピオカガールズバー"
     module: "portal.LoungeTapiokaGirlsbar"
@@ -1505,6 +1691,7 @@ sites:
     enabled: true
     terms_url: "https://lounge-tapioca.com/policy/"
 
+#187
   - site_id: hoskyu
     name: "ホスト求人ドットコム"
     module: "portal.HostKyuzinDotcom_scrape"
@@ -1513,6 +1700,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#188
   - site_id: iiyeah_tateru
     name: "iiYEAH!を建てる"
     module: "construction.iiyeah_tateru"
@@ -1521,6 +1709,7 @@ sites:
     enabled: true
     terms_url: "https://iiyeah-tateru.jp/terms"
 
+#189
   - site_id: philippine_pub
     name: "フィリピンパブどっと混む"
     module: "nightlife.philippine_pub"
@@ -1528,6 +1717,7 @@ sites:
     schedule: "30 4 8-14 * SUN"
     terms_url: "https://philippine-pub.com/terms/"
 
+#190
   - site_id: girlsmeee
     name: "体入ガールズミー"
     module: "nightlife.girlsmeee"
@@ -1536,6 +1726,7 @@ sites:
     enabled: true
     terms_url: "https://girlsmeee.com/policy/terms-of-use"
 
+#191
   - site_id: snack_navi
     name: "スナックナビ"
     module: "nightlife.snack_navi"
@@ -1544,6 +1735,7 @@ sites:
     enabled: true
     terms_url: "https://snacknavi.com/privacy.php"
 
+#192
   - site_id: pachi_town
     name: "DMMぱちタウン"
     module: "nightlife.pachi_town"
@@ -1552,6 +1744,7 @@ sites:
     enabled: true
     terms_url: "https://p-town.dmm.com/terms"
 
+#193
   - site_id: arubaito_ex
     name: "アルバイトEX"
     module: "jobs.arubaito_ex"
@@ -1560,6 +1753,7 @@ sites:
     enabled: true
     terms_url: "https://arubaito-ex.jp/terms"
 
+#194
   - site_id: gaten_info
     name: "ガテン職"
     module: "jobs.gaten_info"
@@ -1568,6 +1762,7 @@ sites:
     enabled: true
     terms_url: "https://gaten.info/apply-terms"
 
+#195
   - site_id: shokuba_mhlw_import
     name: "しょくばらぼ公式CSV差分"
     module: "government.shokuba_mhlw_import"
@@ -1576,6 +1771,7 @@ sites:
     enabled: true
     terms_url: "https://shokuba.mhlw.go.jp/080/010/20180302211203.html"
 
+#196
   - site_id: tattoo_navi
     name: "タットゥースタジオナビ"
     module: "tattoo_navi.tattoo_studio"
@@ -1584,6 +1780,7 @@ sites:
     enabled: true
     terms_url: "https://tattoo-navi.jp/terms/"
 
+#197
   - site_id: onsen_kyokai
     name: "日本温泉協会"
     module: "service.onsen_kyokai"
@@ -1592,6 +1789,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#198
   - site_id: cabacrown
     name: "キャバクラウン"
     module: "jobs.cabacrown"
@@ -1600,6 +1798,7 @@ sites:
     enabled: true
     terms_url: "https://cabacrown.net/contents-regulation/"
 
+#199
   - site_id: tsukulink
     name: "ツクリンク"
     module: "portal.tsukulink"
@@ -1608,6 +1807,7 @@ sites:
     enabled: true
     terms_url: "https://tsukulink.net/term"
 
+#200
   - site_id: naisuta
     name: "ナイスタ"
     module: "jobs.naisuta"
@@ -1616,6 +1816,7 @@ sites:
     enabled: true
     terms_url: "https://naisuta.com/terms/"
 
+#201
   - site_id: nights_fun
     name: "ナイツネット"
     module: "nightlife.nights_fun"
@@ -1624,6 +1825,7 @@ sites:
     enabled: true
     terms_url: "https://www.nights.fun/aichi/membership/"
 
+#202
   - site_id: caba2
     name: "キャバキャバ"
     module: "nightlife.caba2"
@@ -1632,6 +1834,7 @@ sites:
     enabled: true
     terms_url: "https://www.caba2.net/term"
 
+#203
   - site_id: yorunabi
     name: "ヨルナビ"
     module: "nightlife.yorunabi"
@@ -1640,6 +1843,7 @@ sites:
     enabled: true
     terms_url: "https://yorumachi.jp/company.html"
 
+#204
   - site_id: pokepara_tainew
     name: "ポケパラ体入"
     module: "jobs.pokepara_tainew"
@@ -1648,6 +1852,7 @@ sites:
     enabled: true
     terms_url: "https://offer.pokepara-tainew.jp/other/member.html"
 
+#205
   - site_id: eiga_theater
     name: "映画.com 映画館情報"
     module: "portal.eiga_theater"
@@ -1656,6 +1861,7 @@ sites:
     enabled: true
     terms_url: "https://eiga.com/info/kiyaku/"
 
+#206
   - site_id: fitness_search
     name: "フィットネスサーチ"
     module: "portal.fitness_search"
@@ -1664,6 +1870,7 @@ sites:
     enabled: true
     terms_url: "https://www.fitness-search.net/html/terms.html"
 
+#207
   - site_id: sckanto
     name: "日本スイミングクラブ協会関東支部"
     module: "service.sckanto"
@@ -1672,6 +1879,7 @@ sites:
     enabled: true
     terms_url: "https://www.sckanto.net/privacy/"
 
+#208
   - site_id: rakuten_travel
     name: "楽天トラベル 宿泊施設一覧"
     module: "travel.rakuten_travel"
@@ -1680,6 +1888,7 @@ sites:
     enabled: true
     terms_url: "https://travel.rakuten.co.jp/info/"
 
+#209
   - site_id: jalan
     name: "じゃらんnet 宿泊施設"
     module: "portal.jalan"
@@ -1688,6 +1897,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/jln-t-1002/index.html"
 
+#210
   - site_id: type_2
     name: "女の転職type"
     module: "jobs.type_2"
@@ -1696,6 +1906,7 @@ sites:
     enabled: true
     terms_url: "https://woman-type.jp/s/kojin/"
 
+#211
   - site_id: hoteltree_2
     name: "ホテルツリー"
     module: "corporate.hoteltree_2"
@@ -1704,6 +1915,7 @@ sites:
     enabled: true
     terms_url: "https://hoteltree.jp/privacy-policy"
 
+#212
   - site_id: g_channel
     name: "G-CHANNEL"
     module: "nightlife.g_channel"
@@ -1712,6 +1924,7 @@ sites:
     enabled: true
     terms_url: "https://www.g-channel.jp/terms/terms_pc.html"
 
+#213
   - site_id: daikumachi_2
     name: "水戸市大工町地区繁華街なび"
     module: "portal.daikumachi_2"
@@ -1720,6 +1933,7 @@ sites:
     enabled: true
     terms_url: "https://daikumachi.jp/privacy-policy"
 
+#214
   - site_id: takasaki_night_privity_fun
     name: "TAKASAKI NIGHT PRIVITY FUN"
     module: "nightlife.takasaki_night_privity_fun"
@@ -1728,6 +1942,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#215
   - site_id: cute_p
     name: "求とぴ"
     module: "nightlife.cute_p"
@@ -1736,6 +1951,7 @@ sites:
     enabled: true
     terms_url: "http://cute-p.info/kiyaku"
 
+#216
   - site_id: hostgram
     name: "ホスタグラム"
     module: "nightlife.hostgram"
@@ -1744,6 +1960,7 @@ sites:
     enabled: true
     terms_url: "https://hostgram.jp/terms"
 
+#217
   - site_id: meccel_night
     name: "めっけるナイト（栃木版）"
     module: "nightlife.meccel_night"
@@ -1752,6 +1969,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#218
   - site_id: kaigo_kensaku
     name: "介護サービス情報公表システム"
     module: "medical.kaigo_kensaku"
@@ -1760,6 +1978,7 @@ sites:
     enabled: true
     terms_url: "https://www.kaigokensaku.mhlw.go.jp/rule/"
 
+#219
   - site_id: green_japan
     name: "green_japan"
     module: "corporate.green_japan"
@@ -1768,6 +1987,7 @@ sites:
     enabled: true
     terms_url: "https://www.green-japan.com/contents/terms"
 
+#220
   - site_id: ipros
     name: "ipros"
     module: "corporate.ipros"
@@ -1776,6 +1996,7 @@ sites:
     enabled: true
     terms_url: "https://my.ipros.com/legal/"
 
+#221
   - site_id: jarw
     name: "jarw"
     module: "corporate.jarw"
@@ -1784,6 +2005,7 @@ sites:
     enabled: true
     terms_url: "https://www.jarw.or.jp/privacy"
 
+#222
   - site_id: jdcc
     name: "jdcc"
     module: "corporate.jdcc"
@@ -1792,6 +2014,7 @@ sites:
     enabled: true
     terms_url: "https://www.jdcc.or.jp/policy/"
 
+#223
   - site_id: jta_jigyou
     name: "jta_jigyou"
     module: "corporate.jta_jigyou"
@@ -1800,6 +2023,7 @@ sites:
     enabled: true
     terms_url: "https://www.jata-net.or.jp/site_policy/"
 
+#224
   - site_id: nissokyo
     name: "nissokyo"
     module: "corporate.nissokyo"
@@ -1808,6 +2032,7 @@ sites:
     enabled: true
     terms_url: "https://www.nissokyo.or.jp/privacypolicy/"
 
+#225
   - site_id: nittenkyo
     name: "nittenkyo"
     module: "corporate.nittenkyo"
@@ -1816,6 +2041,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#226
   - site_id: web_kanji
     name: "web_kanji"
     module: "corporate.web_kanji"
@@ -1824,6 +2050,7 @@ sites:
     enabled: true
     terms_url: "https://web-kanji.com/terms"
 
+#227
   - site_id: lister_work
     name: "lister_work"
     module: "factory.lister_work"
@@ -1832,6 +2059,7 @@ sites:
     enabled: true
     terms_url: "https://www.lister.work/terms_of_service/"
 
+#228
   - site_id: japan_golf_ngk
     name: "japan_golf_ngk"
     module: "golf.japan_golf_ngk"
@@ -1840,6 +2068,7 @@ sites:
     enabled: true
     terms_url: "https://www.golf-ngk.or.jp/privacy/index.html"
 
+#229
   - site_id: jinzai_hellowork
     name: "jinzai_hellowork"
     module: "government.jinzai_hellowork"
@@ -1848,6 +2077,7 @@ sites:
     enabled: true
     terms_url: "https://www.hellowork.mhlw.go.jp/info/terms.html"
 
+#230
   - site_id: getswork
     name: "getswork"
     module: "jobs.getswork"
@@ -1856,6 +2086,7 @@ sites:
     enabled: true
     terms_url: "https://www.getswork.com/terms.php"
 
+#231
   - site_id: GirlsBaito_scrape
     name: "GirlsBaito_scrape"
     module: "jobs.GirlsBaito_scrape"
@@ -1864,6 +2095,7 @@ sites:
     enabled: true
     terms_url: "https://girlsbaito.jp/kanto/agreement"
 
+#232
   - site_id: HostKyuzinDotcom_scrape
     name: "HostKyuzinDotcom_scrape"
     module: "jobs.HostKyuzinDotcom_scrape"
@@ -1872,6 +2104,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#233
   - site_id: oremichi
     name: "oremichi"
     module: "jobs.oremichi"
@@ -1880,6 +2113,7 @@ sites:
     enabled: true
     terms_url: "https://www.oremichi.com/disclaimer/"
 
+#234
   - site_id: town_life_reform
     name: "town_life_reform"
     module: "jobs.town_life_reform"
@@ -1888,6 +2122,7 @@ sites:
     enabled: true
     terms_url: "https://www.town-life.jp/reform/terms.html"
 
+#235
   - site_id: works
     name: "works"
     module: "jobs.works"
@@ -1896,6 +2131,7 @@ sites:
     enabled: true
     terms_url: "https://04510.jp/policy/"
 
+#236
   - site_id: iko_yo
     name: "iko_yo"
     module: "leisure.iko_yo"
@@ -1904,6 +2140,7 @@ sites:
     enabled: true
     terms_url: "https://iko-yo.net/terms/service"
 
+#237
   - site_id: estelove_work
     name: "estelove_work"
     module: "nightlife.estelove_work"
@@ -1912,6 +2149,7 @@ sites:
     enabled: true
     terms_url: "https://job.eslove.jp/terms"
 
+#238
   - site_id: mens_job
     name: "mens_job"
     module: "nightlife.mens_job"
@@ -1920,6 +2158,7 @@ sites:
     enabled: true
     terms_url: "https://mens-job.jp/privacy_policy/"
 
+#239
   - site_id: nightly
     name: "nightly"
     module: "nightlife.nightly"
@@ -1928,6 +2167,7 @@ sites:
     enabled: true
     terms_url: "https://nightly.jp/terms/"
 
+#240
   - site_id: pachitown
     name: "pachitown"
     module: "nightlife.pachitown"
@@ -1936,6 +2176,7 @@ sites:
     enabled: true
     terms_url: "https://p-town.dmm.com/terms"
 
+#241
   - site_id: queen_work
     name: "queen_work"
     module: "nightlife.queen_work"
@@ -1944,6 +2185,7 @@ sites:
     enabled: true
     terms_url: "https://queenwork.jp/rules.html"
 
+#242
   - site_id: qzin
     name: "qzin"
     module: "nightlife.qzin"
@@ -1952,6 +2194,7 @@ sites:
     enabled: true
     terms_url: "https://www.q-jin.careers/legal/tos.php"
 
+#243
   - site_id: tainyu_route
     name: "tainyu_route"
     module: "nightlife.tainyu_route"
@@ -1960,6 +2203,7 @@ sites:
     enabled: true
     terms_url: "https://icondolllounge.jp/privacy"
 
+#244
   - site_id: yashoku_gorakubu
     name: "yashoku_gorakubu"
     module: "nightlife.yashoku_gorakubu"
@@ -1968,6 +2212,7 @@ sites:
     enabled: true
     terms_url: "https://yorushoku.jp/terms-of-service/"
 
+#245
   - site_id: yorumachi
     name: "yorumachi"
     module: "nightlife.yorumachi"
@@ -1976,6 +2221,7 @@ sites:
     enabled: true
     terms_url: "https://yorumachi.jp/company.html"
 
+#246
   - site_id: beauty_park
     name: "beauty_park"
     module: "portal.beauty_park"
@@ -1984,6 +2230,7 @@ sites:
     enabled: true
     terms_url: "https://www.beauty-park.jp/pages/use_rule/"
 
+#247
   - site_id: bijipuri
     name: "bijipuri"
     module: "portal.bijipuri"
@@ -1992,6 +2239,7 @@ sites:
     enabled: true
     terms_url: "https://visipri.com/privacy.html"
 
+#248
   - site_id: con_cafe
     name: "con_cafe"
     module: "portal.con_cafe"
@@ -2000,6 +2248,7 @@ sites:
     enabled: true
     terms_url: "https://con-cafe.jp/rule"
 
+#249
   - site_id: fukui_shakou
     name: "fukui_shakou"
     module: "portal.fukui_shakou"
@@ -2008,6 +2257,7 @@ sites:
     enabled: true
     terms_url: "https://fukui-syakou.com/privacy-policy"
 
+#250
   - site_id: gal_colle_net
     name: "gal_colle_net"
     module: "portal.gal_colle_net"
@@ -2016,6 +2266,7 @@ sites:
     enabled: true
     terms_url: "https://gal-colle.net/info_cr.php"
 
+#251
   - site_id: girlsbar_station
     name: "girlsbar_station"
     module: "portal.girlsbar_station"
@@ -2024,6 +2275,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#252
   - site_id: imitsu
     name: "imitsu"
     module: "portal.imitsu"
@@ -2032,6 +2284,7 @@ sites:
     enabled: true
     terms_url: "https://imitsu.jp/terms/"
 
+#253
   - site_id: jalan_rentacar
     name: "jalan_rentacar"
     module: "portal.jalan_rentacar"
@@ -2040,6 +2293,7 @@ sites:
     enabled: true
     terms_url: "https://www.jalan.net/rentacar/statics/rentacarkiyaku.html"
 
+#254
   - site_id: jpon
     name: "jpon"
     module: "portal.jpon"
@@ -2048,6 +2302,7 @@ sites:
     enabled: true
     terms_url: "http://www.jpon.jp/kiyaku.html"
 
+#255
   - site_id: kagoshima_shakou
     name: "kagoshima_shakou"
     module: "portal.kagoshima_shakou"
@@ -2056,6 +2311,7 @@ sites:
     enabled: true
     terms_url: "http://www.kagoshima-pub.or.jp/privacy-policy/"
 
+#256
   - site_id: nagano_shakou
     name: "nagano_shakou"
     module: "portal.nagano_shakou"
@@ -2064,6 +2320,7 @@ sites:
     enabled: true
     terms_url: "https://naganosyakouinshyoku.com/privacy-policy/"
 
+#257
   - site_id: niigata_shakou
     name: "niigata_shakou"
     module: "portal.niigata_shakou"
@@ -2072,6 +2329,7 @@ sites:
     enabled: true
     terms_url: "http://niigataken-shakou.com/policy"
 
+#258
   - site_id: okinawa_shakou
     name: "okinawa_shakou"
     module: "portal.okinawa_shakou"
@@ -2080,6 +2338,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#259
   - site_id: reshop_navi
     name: "reshop_navi"
     module: "portal.reshop_navi"
@@ -2088,6 +2347,7 @@ sites:
     enabled: true
     terms_url: "https://rehome-navi.com/informations/terms"
 
+#260
   - site_id: savorjapan
     name: "savorjapan"
     module: "portal.savorjapan"
@@ -2096,6 +2356,7 @@ sites:
     enabled: true
     terms_url: "https://savorjapan.com/terms"
 
+#261
   - site_id: shizuoka_shakou
     name: "shizuoka_shakou"
     module: "portal.shizuoka_shakou"
@@ -2104,6 +2365,7 @@ sites:
     enabled: true
     terms_url: "https://shizuoka-shakou.com/about/privacy"
 
+#262
   - site_id: toyama_shakou
     name: "toyama_shakou"
     module: "portal.toyama_shakou"
@@ -2112,6 +2374,7 @@ sites:
     enabled: true
     terms_url: "http://toyama-syakou.com/privacy-policy/"
 
+#263
   - site_id: tsukulink_naisou
     name: "tsukulink_naisou"
     module: "portal.tsukulink_naisou"
@@ -2120,6 +2383,7 @@ sites:
     enabled: true
     terms_url: "https://tsukulink.net/term"
 
+#264
   - site_id: aupay_japan
     name: "aupay_japan"
     module: "service.aupay_japan"
@@ -2128,6 +2392,7 @@ sites:
     enabled: true
     terms_url: "https://wallet.auone.jp/contents/pc/terms/"
 
+#265
   - site_id: aupay_store
     name: "aupay_store"
     module: "service.aupay_store"
@@ -2136,6 +2401,7 @@ sites:
     enabled: true
     terms_url: "https://account.wowma.jp/docs/tos"
 
+#266
   - site_id: pps_net
     name: "pps_net"
     module: "service.pps_net"
@@ -2144,6 +2410,7 @@ sites:
     enabled: true
     terms_url: "https://pps-net.org/copyright"
 
+#267
   - site_id: xn_pckua2a7gp15o89zb
     name: "求人ボックス【外国人工場夜勤】"
     module: "jobs.xn_pckua2a7gp15o89zb"
@@ -2152,6 +2419,7 @@ sites:
     enabled: true
     terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
+#268
   - site_id: sunmarie
     name: "サンマリエ"
     module: "service.sunmarie"
@@ -2160,6 +2428,7 @@ sites:
     enabled: true
     terms_url: "https://www.sunmarie.co.jp/privacy/"
 
+#269
   - site_id: sunmarie_2
     name: "サンマリエ"
     module: "service.sunmarie_2"
@@ -2168,6 +2437,7 @@ sites:
     enabled: true
     
     terms_url: "https://www.sunmarie.co.jp/copyright/"
+#270
   - site_id: ibj_members
     name: "IBJメンバーズ（結婚相談所）"
     module: "service.ibj_members"
@@ -2176,6 +2446,7 @@ sites:
     enabled: true
     terms_url: "https://www.ibjapan.jp/individual_renmei_lounge"
 
+#271
   - site_id: jpnumber_power_agents
     name: "新電力代理店候補 JPNumber"
     module: "agency_franchise.jpnumber_power_agents"
@@ -2184,6 +2455,7 @@ sites:
     enabled: true
     terms_url: "https://www.jpnumber.com/privacy.html"
 
+#272
   - site_id: milto
     name: "milto（ミルト）"
     module: "jobs.milto"
@@ -2192,6 +2464,7 @@ sites:
     enabled: true
     terms_url: "https://mil-to.com/page/terms/"
 
+#273
   - site_id: tattoo_studio
     name: "タトゥースタジオナビ"
     module: "service.tattoo_studio"
@@ -2200,6 +2473,7 @@ sites:
     enabled: true
     terms_url: "https://tattoo-navi.jp/terms/"
 
+#274
   - site_id: jbn
     name: "JBN"
     module: "construction.jbn"
@@ -2208,6 +2482,7 @@ sites:
     enabled: true
     terms_url: "https://www.jbn-support.jp/privacy/"
 
+#275
   - site_id: cabanori
     name: "キャバノリ"
     module: "nightlife.cabanori"
@@ -2216,6 +2491,7 @@ sites:
     enabled: true
     terms_url: "https://cabanori.com/legal"
 
+#276
   - site_id: ibj_2
     name: "IBJ"
     module: "service.ibj_2"
@@ -2224,6 +2500,7 @@ sites:
     enabled: true
     terms_url: "https://www.ibjapan.jp/sitepolicy"
 
+#277
   - site_id: torecamap
     name: "トレカの地図"
     module: "service.torecamap"
@@ -2232,6 +2509,7 @@ sites:
     enabled: true
     terms_url: "https://torecamap.co.jp/rules"
 
+#278
   - site_id: kimonoya
     name: "着物屋さんナビ"
     module: "service.kimonoya"
@@ -2240,6 +2518,7 @@ sites:
     enabled: true
     terms_url: "https://www.kimonoya.org/privacy.html"
 
+#279
   - site_id: hatarakuzo
     name: "働くぞドットコム"
     module: "jobs.hatarakuzo"
@@ -2248,6 +2527,7 @@ sites:
     enabled: true
     terms_url: "https://www.hatarakuzo.com/pages/rule"
 
+#280
   - site_id: snakaranavi
     name: "スナカラ"
     module: "nightlife.snakaranavi"
@@ -2256,6 +2536,7 @@ sites:
     enabled: true
     terms_url: "https://www.snakaranavi.net/privacy.php"
 
+#281
   - site_id: techplaza
     name: "東大阪市技術交流プラザ"
     module: "government.techplaza"
@@ -2264,6 +2545,7 @@ sites:
     enabled: true
     terms_url: "https://www.techplaza.city.higashiosaka.osaka.jp/help/notesonuse"
 
+#282
   - site_id: tsukulink_2
     name: "ツクリンクリスト"
     module: "portal.tsukulink_2"
@@ -2272,6 +2554,7 @@ sites:
     enabled: true
     terms_url: "https://tsukulink.net/term"
 
+#283
   - site_id: night
     name: "神奈川夜遊びNight"
     module: "nightlife.night"
@@ -2280,6 +2563,7 @@ sites:
     enabled: true
     terms_url: "https://www.kanagawa-yoasobi.com/data.php?c=policy"
 
+#284
   - site_id: enecho
     name: "登録小売電気事業者"
     module: "government.enecho"
@@ -2288,6 +2572,7 @@ sites:
     enabled: true
     terms_url: "https://www.enecho.meti.go.jp/about/linksto_thissite/"
 
+#285
   - site_id: cabanori_3
     name: "ハマのり"
     module: "nightlife.cabanori_3"
@@ -2296,6 +2581,7 @@ sites:
     enabled: true
     terms_url: "https://cabanori.com/legal"
 
+#286
   - site_id: web_2
     name: "web幹事"
     module: "corporate.web_2"
@@ -2304,6 +2590,7 @@ sites:
     enabled: true
     terms_url: "https://web-kanji.com/terms"
 
+#287
   - site_id: cookdoor_2
     name: "クックドア"
     module: "food.cookdoor_2"
@@ -2312,6 +2599,7 @@ sites:
     enabled: true
     terms_url: "https://www.homemate-research.com/info/rule/"
 
+#288
   - site_id: etsuran2_4
     name: "建設業者・宅建業者等企業情報検索システム【建設業者】"
     module: "construction.etsuran2_4"
@@ -2320,6 +2608,7 @@ sites:
     enabled: true
     terms_url: "https://www.digital.go.jp/resources/open_data/public_data_license_v1.0"
 
+#289
   - site_id: tabiiro
     name: "旅色(宿)"
     module: "leisure.tabiiro"
@@ -2328,6 +2617,7 @@ sites:
     enabled: true
     terms_url: "https://tabiiro.jp/regulation/"
 
+#290
   - site_id: wam
     name: "障害福祉サービス情報検索"
     module: "government.wam"
@@ -2336,6 +2626,7 @@ sites:
     enabled: true
     terms_url: "https://www.wam.go.jp/content/wamnet/pcpub/syogai/shofukupubsys/shofukupubsys02.html"
 
+#291
   - site_id: kenken
     name: "KenKen!"
     module: "construction.kenken"
@@ -2344,6 +2635,7 @@ sites:
     enabled: true
     terms_url: "https://www.kenchikukenken.co.jp/menseki.html"
 
+#292
   - site_id: clearing
     name: "登録貸金業者情報検索"
     module: "government.clearing"
@@ -2352,6 +2644,7 @@ sites:
     enabled: true
     terms_url: "https://www.fsa.go.jp/ordinary/kensaku/chuui.html"
 
+#293
   - site_id: search
     name: "金融商品取引業者等一覧"
     module: "government.search"
@@ -2360,6 +2653,7 @@ sites:
     enabled: true
     terms_url: "https://www.fsa.go.jp/rules/index.html"
 
+#294
   - site_id: etsuran2_5
     name: "建設業者・宅建業者等企業情報検索システム【マンション管理業者】"
     module: "construction.etsuran2_5"
@@ -2368,6 +2662,7 @@ sites:
     enabled: true
     terms_url: "https://www.digital.go.jp/resources/open_data/public_data_license_v1.0"
 
+#295
   - site_id: keaj
     name: "在日中国朝鮮族経営者協会"
     module: "corporate.keaj"
@@ -2376,6 +2671,7 @@ sites:
     enabled: true
     terms_url: "https://keaj.org/privacy-policy"
 
+#296
   - site_id: caretaxi_net
     name: "介護タクシー案内所"
     module: "service.caretaxi_net"
@@ -2384,6 +2680,7 @@ sites:
     enabled: true
     terms_url: "https://caretaxi-net.com/term/"
 
+#297
   - site_id: jcata
     name: "在日華人旅行業協会公式"
     module: "corporate.jcata"
@@ -2392,6 +2689,7 @@ sites:
     enabled: true
     terms_url: "https://www.churenkyo.com/churenkyo_kiyaku.html"
 
+#298
   - site_id: dancesagasu
     name: "ダンサガ"
     module: "leisure.dancesagasu"
@@ -2400,6 +2698,7 @@ sites:
     enabled: true
     terms_url: "https://dancesagasu.net/rule/"
 
+#299
   - site_id: npo
     name: "内閣府NPO法人情報ポータルサイト"
     module: "government.npo"
@@ -2408,6 +2707,7 @@ sites:
     enabled: true
     terms_url: "https://www.npo-homepage.go.jp/npoportal/create/agreement"
 
+#300
   - site_id: kyujin
     name: "ほっとサーチ"
     module: "nightlife.kyujin"
@@ -2416,6 +2716,7 @@ sites:
     enabled: true
     terms_url: "https://kyujin.hotsearch.jp/kiyaku.html"
 
+#301
   - site_id: cabasite
     name: "cabasite"
     module: "nightlife.cabasite"
@@ -2424,6 +2725,7 @@ sites:
     enabled: true
     terms_url: "https://cabasite.com/info.php?type=terms&id=TERMS"
 
+#302
   - site_id: iryou
     name: "医療情報ネット（ナビイ）"
     module: "medical.iryou"
@@ -2432,6 +2734,7 @@ sites:
     enabled: true
     terms_url: "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/kenkou_iryou/iryou/index_00004.html"
 
+#303
   - site_id: arukita
     name: "アルキタ"
     module: "jobs.arukita"
@@ -2440,6 +2743,7 @@ sites:
     enabled: true
     terms_url: "https://www.haj.co.jp/rules/?mediaid=1"
 
+#304
   - site_id: kaigoshoku
     name: "マイナビ介護職"
     module: "jobs.kaigoshoku"
@@ -2448,6 +2752,7 @@ sites:
     enabled: true
     terms_url: "https://kaigoshoku.mynavi.jp/kiyaku"
 
+#305
   - site_id: demae_can_8
     name: "出前館"
     module: "food.demae_can_8"
@@ -2456,6 +2761,7 @@ sites:
     enabled: true
     terms_url: "https://demae-can.com/navigate/termsofuse"
 
+#306
   - site_id: jadma
     name: "JADMA 正会員一覧"
     module: "corporate.jadma"
@@ -2464,6 +2770,7 @@ sites:
     enabled: true
     terms_url: "https://jadma.or.jp/use"
 
+#307
   - site_id: re
     name: "Re就活"
     module: "jobs.re"
@@ -2472,6 +2779,7 @@ sites:
     enabled: true
     terms_url: "https://re-katsu.jp/career/contents/kiyaku/index.html"
 
+#308
   - site_id: it
     name: "ITトレンド"
     module: "corporate.it"
@@ -2480,6 +2788,7 @@ sites:
     enabled: true
     terms_url: "https://it-trend.jp/help/term"
 
+#309
   - site_id: boxil
     name: "BOXIL"
     module: "portal.boxil"
@@ -2488,6 +2797,7 @@ sites:
     enabled: true
     terms_url: "https://boxil.jp/terms/"
 
+#310
   - site_id: emidas_2
     name: "エミダス(emidas)"
     module: "corporate.emidas_2"
@@ -2496,6 +2806,7 @@ sites:
     enabled: true
     terms_url: "https://emidas.jp/rule"
 
+#311
   - site_id: zenshukyo
     name: "全日本宗教用具協同組合(仏具)"
     module: "government.zenshukyo"
@@ -2504,6 +2815,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#312
   - site_id: softbank
     name: "ソフトバンクショップ"
     module: "agency_franchise.softbank"
@@ -2512,6 +2824,7 @@ sites:
     enabled: true
     terms_url: "https://www.softbank.jp/help/terms/"
 
+#313
   - site_id: www5
     name: "認定補聴器専門店認定システム"
     module: "medical.www5"
@@ -2520,6 +2833,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#314
   - site_id: ii_ie2
     name: "いい家ネット"
     module: "construction.ii_ie2"
@@ -2528,6 +2842,7 @@ sites:
     enabled: true
     terms_url: "https://www.ii-ie2.net/terms/"
 
+#315
   - site_id: p_portal
     name: "調達ポータル【法人】"
     module: "government.p_portal"
@@ -2536,6 +2851,7 @@ sites:
     enabled: true
     terms_url: "https://www.p-portal.go.jp/pps-web-biz/resources/app/pdf/riyoukiyaku.pdf"
 
+#316
   - site_id: epark
     name: "EPARKリラク＆エステ"
     module: "beauty.epark"
@@ -2544,6 +2860,7 @@ sites:
     enabled: true
     terms_url: "https://mitsuraku.jp/agreement/"
 
+#317
   - site_id: store
     name: "ほっともっと"
     module: "food.store"
@@ -2552,6 +2869,7 @@ sites:
     enabled: true
     terms_url: "https://www.hottomotto.com/policy/terms_of_use.html"
 
+#318
   - site_id: p_portal_4
     name: "調達ポータル【個人】"
     module: "government.p_portal_4"
@@ -2560,6 +2878,7 @@ sites:
     enabled: true
     terms_url: "https://www.p-portal.go.jp/pps-web-biz/resources/app/pdf/riyoukiyaku.pdf"
 
+#319
   - site_id: catr
     name: "官報"
     module: "corporate.catr"
@@ -2568,6 +2887,7 @@ sites:
     enabled: true
     terms_url: "https://search.npb.go.jp/guide/kiyaku.html"
 
+#320
   - site_id: ntt
     name: "NTT東日本 光コラボレーションモデル 事業者一覧"
     module: "corporate.ntt"
@@ -2576,6 +2896,7 @@ sites:
     enabled: true
     terms_url: "https://flets.com/requirements.html"
 
+#321
   - site_id: ntt_2
     name: "NTT西日本 光コラボレーションモデル 事業者一覧"
     module: "agency_franchise.ntt_2"
@@ -2584,6 +2905,7 @@ sites:
     enabled: true
     terms_url: "https://www.ntt-west.co.jp/share/aboutsite.html"
 
+#322
   - site_id: houjin_bangou
     name: "国税庁　法人番号公表サイト"
     module: "government.houjin_bangou"
@@ -2592,6 +2914,7 @@ sites:
     enabled: true
     terms_url: "https://www.houjin-bangou.nta.go.jp/riyokiyaku/index.html"
 
+#323
   - site_id: baitoru_2
     name: "(バイトル)　ほっともっと"
     module: "jobs.baitoru_2"
@@ -2600,6 +2923,7 @@ sites:
     enabled: true
     terms_url: "https://www.baitoru.com/about/kiyaku_base.html"
 
+#324
   - site_id: bar_navi
     name: "バーナビ　 BAR-NAVI"
     module: "food.bar_navi"
@@ -2608,6 +2932,7 @@ sites:
     enabled: true
     terms_url: "https://bar-navi.suntory.co.jp/terms.html"
 
+#325
   - site_id: bar_find
     name: "バーファインド"
     module: "food.bar_find"
@@ -2616,6 +2941,7 @@ sites:
     enabled: true
     terms_url: "https://bar-find.com/main/terms_user"
 
+#326
   - site_id: brunavi
     name: "ブルナビ"
     module: "nightlife.brunavi"
@@ -2624,6 +2950,7 @@ sites:
     enabled: true
     terms_url: "https://brunavi.com/?mode=policy"
 
+#327
   - site_id: xn_pckua2a7gp15o89zb_2
     name: "求人ボックス（ナイトワーク系求人）"
     module: "jobs.xn_pckua2a7gp15o89zb_2"
@@ -2632,6 +2959,7 @@ sites:
     enabled: true
     terms_url: "https://xn--pckua2a7gp15o89zb.com/%E5%88%A9%E7%94%A8%E8%A6%8F%E7%B4%84"
 
+#328
   - site_id: jp
     name: "スタンバイ"
     module: "jobs.jp_stanby"
@@ -2640,6 +2968,7 @@ sites:
     enabled: true
     terms_url: "https://jp.stanby.com/about/terms"
 
+#329
   - site_id: nomu
     name: "ノムノム"
     module: "nightlife.nomu"
@@ -2648,6 +2977,7 @@ sites:
     enabled: true
     terms_url: "https://home.tsuku2.jp/terms.php"
 
+#330
   - site_id: snack_guide
     name: "スナックガイド"
     module: "nightlife.snack_guide"
@@ -2656,6 +2986,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#331
   - site_id: cabanavi
     name: "キャバナビ"
     module: "nightlife.cabanavi"
@@ -2664,6 +2995,7 @@ sites:
     enabled: true
     terms_url: "https://cabanavi.info/navi/page/4395/"
 
+#332
   - site_id: town_night
     name: "夜遊びショコラ（東北）"
     module: "nightlife.town_night"
@@ -2672,6 +3004,7 @@ sites:
     enabled: true
     terms_url: "https://town-night.jp/terms/"
 
+#333
   - site_id: web_3
     name: "ルーキーWeb"
     module: "jobs.web_3"
@@ -2680,6 +3013,7 @@ sites:
     enabled: true
     terms_url: "https://www.shigotoarimasu.com/article/303"
 
+#334
   - site_id: noxgroup
     name: "ノックスグループ"
     module: "nightlife.noxgroup"
@@ -2688,6 +3022,7 @@ sites:
     enabled: true
     terms_url: "https://www.noxgroup2021.com/policy"
 
+#335
   - site_id: agre
     name: "Agre"
     module: "jobs.agre"
@@ -2696,6 +3031,7 @@ sites:
     enabled: true
     terms_url: "https://webagre.com/job/terms_of_service"
 
+#336
   - site_id: nightgram
     name: "ナイトグラム"
     module: "nightlife.nightgram"
@@ -2704,6 +3040,7 @@ sites:
     enabled: true
     terms_url: "https://nightgram.com/terms"
 
+#337
   - site_id: ac_lab
     name: "アクセス就活2027"
     module: "jobs.ac_lab"
@@ -2712,6 +3049,7 @@ sites:
     enabled: true
     terms_url: "https://www.ac-lab.jp/media/rule_ac/"
 
+#338
   - site_id: tsunoru
     name: "TSUNORU既卒第二新卒"
     module: "jobs.tsunoru"
@@ -2720,6 +3058,7 @@ sites:
     enabled: true
     terms_url: "https://job.tsunoru.jp/doc/terms_company.pdf"
 
+#339
   - site_id: night_works
     name: "キャバクラ求人ホッケ"
     module: "nightlife.night_works"
@@ -2728,6 +3067,7 @@ sites:
     enabled: true
     terms_url: "https://night-works.com/privacypolicy/"
 
+#340
   - site_id: webagre
     name: "アグレキャリア"
     module: "jobs.webagre"
@@ -2736,6 +3076,7 @@ sites:
     enabled: true
     terms_url: "https://webagre.com/career/membership_agreement"
 
+#341
   - site_id: https_bunbunweb_com_shop
     name: "BunBunweb_国分町"
     module: "nightlife.https_bunbunweb_com_shop"
@@ -2744,6 +3085,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#342
   - site_id: luline
     name: "夜のお店選びドットコム（東北版）"
     module: "nightlife.luline"
@@ -2752,6 +3094,7 @@ sites:
     enabled: true
     terms_url: "https://tainew-tohoku.com/menu/terms/"
 
+#343
   - site_id: re30
     name: "Re就活30"
     module: "jobs.re30"
@@ -2760,6 +3103,7 @@ sites:
     enabled: true
     terms_url: "https://re-katsu30.jp/kiyaku/"
 
+#344
   - site_id: pacola
     name: "パコラ"
     module: "jobs.pacola"
@@ -2768,6 +3112,7 @@ sites:
     enabled: true
     terms_url: "https://www.pacola.co.jp/privacy/"
 
+#345
   - site_id: job
     name: "メリット"
     module: "jobs.job"
@@ -2776,6 +3121,7 @@ sites:
     enabled: true
     terms_url: "https://www.merit-inc.co/privacy/"
 
+#346
   - site_id: i_select
     name: "iセレクト"
     module: "jobs.i_select"
@@ -2784,6 +3130,7 @@ sites:
     enabled: true
     terms_url: "http://www.i-select.jp/terms"
 
+#347
   - site_id: atsumaru
     name: "あつまるくんの求人案内"
     module: "jobs.atsumaru"
@@ -2792,6 +3139,7 @@ sites:
     enabled: true
     terms_url: "https://atsumaru.jp/terms"
 
+#348
   - site_id: e_aidem
     name: "イーアイデム【全国】"
     module: "jobs.e_aidem"
@@ -2800,6 +3148,7 @@ sites:
     enabled: true
     terms_url: "https://www.e-aidem.com/contents/info/kiyaku.htm"
 
+#349
   - site_id: e_arpa
     name: "アルパ"
     module: "jobs.e_arpa"
@@ -2808,6 +3157,7 @@ sites:
     enabled: true
     terms_url: "https://www.kg-net.co.jp/information/service-rule.php"
 
+#350
   - site_id: workin
     name: "workin岡山県"
     module: "jobs.workin"
@@ -2816,6 +3166,7 @@ sites:
     enabled: true
     terms_url: "https://workin.jp/static/kiyaku"
 
+#351
   - site_id: keeperproshop
     name: "KeePerPROSHOP_洗車関連"
     module: "auto.keeperproshop"
@@ -2824,6 +3175,7 @@ sites:
     enabled: true
     terms_url: "https://www.keepercoating.jp/privacy/"
 
+#352
   - site_id: d_starjob
     name: "ディースターネット"
     module: "jobs.d_starjob"
@@ -2832,6 +3184,7 @@ sites:
     enabled: true
     terms_url: "https://d-starjob.com/etc/kiyaku.html"
 
+#353
   - site_id: domo_2
     name: "DOMO静岡"
     module: "jobs.domo_2"
@@ -2840,6 +3193,7 @@ sites:
     enabled: true
     terms_url: "https://domonet.jp/info/agreement"
 
+#354
   - site_id: ad_sanai
     name: "アドサンアイ"
     module: "jobs.ad_sanai"
@@ -2848,6 +3202,7 @@ sites:
     enabled: true
     terms_url: "https://www.ad-sanai.co.jp/goriyou"
 
+#355
   - site_id: domo_net
     name: "DOMO NET(ドモネット)"
     module: "jobs.domo_net"
@@ -2856,6 +3211,7 @@ sites:
     enabled: true
     terms_url: "https://domonet.jp/info/agreement"
 
+#356
   - site_id: club_jt
     name: "CLUB　JT"
     module: "service.club_jt"
@@ -2864,6 +3220,7 @@ sites:
     enabled: true
     terms_url: "https://www.clubjt.jp/terms/clubjt-terms/"
 
+#357
   - site_id: jp_2
     name: "スタンバイ　ナイトワーク"
     module: "nightlife.jp_2"
@@ -2872,6 +3229,7 @@ sites:
     enabled: true
     terms_url: "https://standby-corp.jp/standby-terms-of-use/"
 
+#358
   - site_id: jobkita
     name: "ジョブキタ"
     module: "jobs.jobkita"
@@ -2880,6 +3238,7 @@ sites:
     enabled: true
     terms_url: "https://www.haj.co.jp/rules/?mediaid=3"
 
+#359
   - site_id: sgnavi
     name: "sgnavi"
     module: "jobs.sgnavi"
@@ -2888,6 +3247,7 @@ sites:
     enabled: true
     terms_url: "https://www.sgnavi.com/hokkaido/terms-of-service/"
 
+#360
   - site_id: yell
     name: "エール"
     module: "jobs.yell"
@@ -2896,6 +3256,7 @@ sites:
     enabled: true
     terms_url: "https://herp.careers/careers/terms"
 
+#361
   - site_id: girls_good_job
     name: "girls good job"
     module: "nightlife.girls_good_job"
@@ -2904,6 +3265,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#362
   - site_id: tainew_walker
     name: "体入キャストウォーカー"
     module: "nightlife.tainew_walker"
@@ -2914,6 +3276,7 @@ sites:
 
  
 
+#363
   - site_id: luline_2
     name: "夜のお店選びドットコム"
     module: "nightlife.luline_2"
@@ -2922,6 +3285,7 @@ sites:
     enabled: true
     terms_url: "https://luline.jp/about/terms/"
 
+#364
   - site_id: kensetsu_databank
     name: "建築計画のお知らせ看板情報【首都圏】"
     module: "construction.kensetsu_databank"
@@ -2930,6 +3294,7 @@ sites:
     enabled: true
     terms_url: "https://www.kensetsu-databank.co.jp/privacy/"
 
+#365
   - site_id: girlswork
     name: "がーるずわーく"
     module: "jobs.girlswork"
@@ -2938,6 +3303,7 @@ sites:
     enabled: true
     terms_url: "https://girlswork.jp/terms-of-service/"
 
+#366
   - site_id: kensetsu_databank_2
     name: "建築計画のお知らせ看板情報"
     module: "construction.kensetsu_databank_2"
@@ -2946,6 +3312,7 @@ sites:
     enabled: true
     terms_url: "https://kdb.tokyo/aboutus/privacy.html"
 
+#367
   - site_id: con_girl
     name: "コンガール"
     module: "nightlife.con_girl"
@@ -2954,6 +3321,7 @@ sites:
     enabled: true
     terms_url: "https://con-girl.com/userpolicy"
 
+#368
   - site_id: tainew
     name: "体入ドットコム"
     module: "nightlife.tainew"
@@ -2962,6 +3330,7 @@ sites:
     enabled: true
     terms_url: "https://www.tainew.com/menu/terms/"
 
+#369
   - site_id: jasmac8
     name: "ジャスマック八戸館"
     module: "nightlife.jasmac8"
@@ -2970,6 +3339,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#370
   - site_id: japanshishatimes
     name: "シーシャマップジャパン"
     module: "nightlife.japanshishatimes"
@@ -2978,6 +3348,7 @@ sites:
     enabled: true
     terms_url: "https://www.japanshishatimes.jp/terms-of-use"
 
+#371
   - site_id: prefer_work
     name: "Prefer Work"
     module: "nightlife.prefer_work"
@@ -2986,6 +3357,7 @@ sites:
     enabled: true
     terms_url: "https://offer-prefer.site/policy/"
 
+#372
   - site_id: ekimae_lab
     name: "エキラボ"
     module: "nightlife.ekimae_lab"
@@ -2994,6 +3366,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#373
   - site_id: foul
     name: "ファウルプラチナム"
     module: "nightlife.foul"
@@ -3002,6 +3375,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#374
   - site_id: navi_2
     name: "便利屋さんNAVI"
     module: "service.navi_2"
@@ -3010,6 +3384,7 @@ sites:
     enabled: true
     terms_url: "https://benriyanavi.com/disclaimer.html"
 
+#375
   - site_id: nightstyle_2
     name: "ナイト_ナイトスタイル"
     module: "nightlife.nightstyle_2"
@@ -3018,6 +3393,7 @@ sites:
     enabled: true
     terms_url: "https://nightstyle.jp/terms/"
 
+#376
   - site_id: girlsbar_prds
     name: "ガルバパラダイス"
     module: "nightlife.girlsbar_prds"
@@ -3026,6 +3402,7 @@ sites:
     enabled: true
     terms_url: "https://girlsbar-prds.net/grp/Terms.html"
 
+#377
   - site_id: benriya_paradise
     name: "便利屋パラダイス"
     module: "service.benriya_paradise"
@@ -3034,6 +3411,7 @@ sites:
     enabled: true
     terms_url: "https://benriya-paradise.com/terms"
 
+#378
   - site_id: helper
     name: "便利屋お助けナビ"
     module: "service.helper"
@@ -3042,6 +3420,7 @@ sites:
     enabled: true
     terms_url: "https://helper.kokoroegao.com/terms/"
 
+#379
   - site_id: benriya_paradise_2
     name: "便利屋 パラダイス"
     module: "service.benriya_paradise_2"
@@ -3050,6 +3429,7 @@ sites:
     enabled: true
     terms_url: "https://benriya-paradise.com/terms"
 
+#380
   - site_id: navi_3
     name: "便利屋さん NAVI"
     module: "service.navi_3"
@@ -3058,6 +3438,7 @@ sites:
     enabled: true
     terms_url: "https://benriyanavi.com/disclaimer.html"
 
+#381
   - site_id: helper_2
     name: "便利屋お助け ナビ"
     module: "service.helper_2"
@@ -3066,6 +3447,7 @@ sites:
     enabled: true
     terms_url: "https://helper.kokoroegao.com/terms/"
 
+#382
   - site_id: jobmake
     name: "ジョブメイク"
     module: "jobs.jobmake"
@@ -3074,6 +3456,7 @@ sites:
     enabled: true
     terms_url: "https://www.jobmake.jp/privacy"
 
+#383
   - site_id: mycareer_jp
     name: "ミツケル"
     module: "jobs.mycareer_jp"
@@ -3082,6 +3465,7 @@ sites:
     enabled: true
     terms_url: "https://mitsukel.co.jp/terms/"
 
+#384
   - site_id: builders_ranking
     name: "ビルダーランキング"
     module: "construction.builders_ranking"
@@ -3090,6 +3474,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#385
   - site_id: nap_camp
     name: "なっぷ"
     module: "leisure.nap_camp"
@@ -3098,6 +3483,7 @@ sites:
     enabled: true
     terms_url: "https://www.nap-camp.com/support_data/terms/6_nap_agreement.pdf"
 
+#386
   - site_id: nextinjapan
     name: "nextinjapan"
     module: "jobs.nextinjapan"
@@ -3106,6 +3492,7 @@ sites:
     enabled: true
     terms_url: "https://nextinjapan.com/terms"
 
+#387
   - site_id: q_jinkun
     name: "求人君"
     module: "jobs.q_jinkun"
@@ -3114,6 +3501,7 @@ sites:
     enabled: true
     terms_url: "https://www.q-jinkun.com/privacypolicy/"
 
+#388
   - site_id: workinfree
     name: "WorkinFree"
     module: "jobs.workinfree"
@@ -3122,6 +3510,7 @@ sites:
     enabled: true
     terms_url: "https://workin.jp/static/kiyaku"
 
+#389
   - site_id: re_2
     name: "Re就活（やり直し）"
     module: "jobs.re_2"
@@ -3130,6 +3519,7 @@ sites:
     enabled: true
     terms_url: "https://re-katsu.jp/career/contents/kiyaku/index.html"
 
+#390
   - site_id: navi_4
     name: "片町ナイトNAVI"
     module: "nightlife.navi_4"
@@ -3138,6 +3528,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#391
   - site_id: guide_jp
     name: "浜松ナイトガイド"
     module: "nightlife.guide_jp"
@@ -3146,6 +3537,7 @@ sites:
     enabled: true
     terms_url: "https://guide-jp.com/guideline/"
 
+#392
   - site_id: matsumoto_angel
     name: "長野ナイトナビ"
     module: "nightlife.matsumoto_angel"
@@ -3154,6 +3546,7 @@ sites:
     enabled: true
     terms_url: "https://www.matsumoto-angel.net/night/static/info/rule.html"
 
+#393
   - site_id: kofu_angel
     name: "山梨ナイトナビ"
     module: "nightlife.kofu_angel"
@@ -3162,6 +3555,7 @@ sites:
     enabled: true
     terms_url: "https://www.kofu-angel.net/fuuzoku/rule/"
 
+#394
   - site_id: cabasite_2
     name: "キャバサイト"
     module: "nightlife.cabasite_2"
@@ -3170,6 +3564,7 @@ sites:
     enabled: true
     terms_url: "https://cabasite.com/info.php?type=terms&id=TERMS"
 
+#395
   - site_id: pokepara
     name: "ポケパラ"
     module: "nightlife.pokepara"
@@ -3178,6 +3573,7 @@ sites:
     enabled: true
     terms_url: "https://www.pokepara.jp/kanto/agree.html"
 
+#396
   - site_id: good_staff
     name: "Good Staff"
     module: "jobs.good_staff"
@@ -3186,6 +3582,7 @@ sites:
     enabled: true
     terms_url: "https://entori.jp/goodstaff/rules"
 
+#397
   - site_id: bizcomm
     name: "ビズコミ"
     module: "jobs.bizcomm"
@@ -3194,6 +3591,7 @@ sites:
     enabled: true
     terms_url: "https://bizcomm.net/terms-of-service"
 
+#398
   - site_id: shigoto100
     name: "日本仕事百貨"
     module: "jobs.shigoto100"
@@ -3202,6 +3600,7 @@ sites:
     enabled: true
     terms_url: "https://shigoto100.com/userpolicy"
 
+#399
   - site_id: myhome
     name: "ニフティ不動産（不動産会社・不動産屋を探す）"
     module: "realestate.myhome"
@@ -3210,6 +3609,7 @@ sites:
     enabled: true
     terms_url: "https://niftylifestyle.co.jp/term/myhome/"
 
+#400
   - site_id: job_2
     name: "彩job"
     module: "jobs.job_2"
@@ -3218,6 +3618,7 @@ sites:
     enabled: true
     terms_url: "無し"
 
+#401
   - site_id: jobway
     name: "Jobway"
     module: "corporate.jobway"
@@ -3226,6 +3627,7 @@ sites:
     enabled: true
     terms_url: "https://www.jobway.jp/terms"
 
+#402
   - site_id: bizreach_2
     name: "ビズリーチ"
     module: "corporate.bizreach_2"
@@ -3234,6 +3636,7 @@ sites:
     enabled: true
     terms_url: "https://www.bizreach.jp/pages/service/rules/"
 
+#403
   - site_id: paiza
     name: "paiza"
     module: "jobs.paiza"
@@ -3241,6 +3644,7 @@ sites:
     schedule: "0 17 10 * *"
     terms_url: ""
 
+#404
   - site_id: mynavi_baito
     name: "マイナビバイト"
     module: "jobs.mynavi_baito"
@@ -3249,6 +3653,7 @@ sites:
     enabled: true
     terms_url: "https://baito.mynavi.jp/static/terms.html"
   
+#405
   - site_id: froma
     name: "フロムエーナビ"
     module: "jobs.froma"
@@ -3257,6 +3662,7 @@ sites:
     enabled: true
     terms_url: "https://www.help.froma.com/s/article/000025050"
 
+#406
   - site_id: 01intern
     name: "ゼロワンインターン"
     module: "jobs.01intern"
@@ -3265,6 +3671,7 @@ sites:
     enabled: true
     terms_url: "https://01intern.com/terms.html"
 
+#407
   - site_id: job_3
     name: "キャリタス就活"
     module: "jobs.job_3"
@@ -3273,6 +3680,7 @@ sites:
     enabled: true
     terms_url: "https://job.career-tasu.jp/membership-agreement/"
 
+#408
   - site_id: bunnabi
     name: "ブンナビ(2027)"
     module: "corporate.bunnabi"
@@ -3281,6 +3689,7 @@ sites:
     enabled: true
     terms_url: ""
 
+#409
   - site_id: emeao
     name: "エミーオ(EMEAO)"
     module: "corporate.emeao"
@@ -3289,6 +3698,7 @@ sites:
     enabled: true
     terms_url: "https://emeao.jp/policy/"
 
+#410
   - site_id: metoree
     name: "Metoree（メトリー）"
     module: "corporate.metoree"
@@ -3297,6 +3707,7 @@ sites:
     enabled: true
     terms_url: "https://metoree.com/terms/"
 
+#411
   - site_id: mitsuri
     name: "Mitsuri(ミツリ)"
     module: "factory.mitsuri"
@@ -3305,6 +3716,7 @@ sites:
     enabled: true
     terms_url: "https://help.mitsu-ri.net/help/terms-user"
 
+#412
   - site_id: town_life
     name: "タウンライフリフォーム"
     module: "construction.town_life"
@@ -3313,6 +3725,7 @@ sites:
     enabled: true
     terms_url: "https://www.town-life.jp/toppage/terms.html"
 
+#413
   - site_id: lifull_home_s
     name: "LIFULL HOME'S 注文住宅(ライフルホームズ)"
     module: "realestate.lifull_home_s"
@@ -3321,6 +3734,7 @@ sites:
     enabled: true
     terms_url: "https://www.homes.co.jp/kiyaku/"
 
+#414
   - site_id: hikkoshizamurai
     name: "引越し侍"
     module: "service.hikkoshizamurai"
@@ -3329,6 +3743,7 @@ sites:
     enabled: true
     terms_url: "https://hikkoshizamurai.jp/popup/terms.html"
 
+#415
   - site_id: relax_job
     name: "リジョブ"
     module: "jobs.relax_job"
@@ -3337,6 +3752,7 @@ sites:
     enabled: true
     terms_url: "https://relax-job.com/info/terms"
 
+#416
   - site_id: e_sogi
     name: "いい葬儀"
     module: "service.e_sogi"
@@ -3345,6 +3761,7 @@ sites:
     enabled: true
     terms_url: "https://www.kamakura-net.co.jp/servicepolicy/"
 
+#417
   - site_id: osohshiki
     name: "小さなお葬式"
     module: "service.osohshiki"
@@ -3353,6 +3770,7 @@ sites:
     enabled: true
     terms_url: ""
 
+#418
   - site_id: zeiri4
     name: "税理士ドットコム"
     module: "corporate.zeiri4"
@@ -3361,6 +3779,7 @@ sites:
     enabled: true
     terms_url: "https://www.zeiri4.com/rules/"
 
+#419
   - site_id: bengo4
     name: "弁護士ドットコム"
     module: "service.bengo4"
@@ -3369,6 +3788,7 @@ sites:
     enabled: true
     terms_url: "https://www.bengo4.com/rules/general/"
 
+#420
   - site_id: hanayume
     name: "HANAYUME(ハナユメ)"
     module: "service.hanayume"
@@ -3377,6 +3797,7 @@ sites:
     enabled: true
     terms_url: "https://hana-yume.net/pages/rule/"
 
+#421
   - site_id: eslove
     name: "エステラブ"
     module: "nightlife.eslove"
@@ -3385,6 +3806,7 @@ sites:
     enabled: true
     terms_url: ""
 
+#422
   - site_id: crowdworks
     name: "クラウドワークス"
     module: "jobs.crowdworks"
@@ -3393,6 +3815,7 @@ sites:
     enabled: true
     terms_url: "https://crowdworks.jp/pages/agreement"
 
+#423
   - site_id: zexy
     name: "ゼクシィ"
     module: "service.zexy"
@@ -3401,6 +3824,7 @@ sites:
     enabled: true
     terms_url: "https://cdn.p.recruit.co.jp/terms/zxy-t-1003/index.html"
 
+#424
   - site_id: baitoru_5
     name: "バイトル関西_工場"
     module: "jobs.baitoru_5"
@@ -3409,6 +3833,7 @@ sites:
     enabled: true
     terms_url: "https://www.baitoru.com/about/kiyaku_base.html"
 
+#425
   - site_id: sumitec_kanto_2
     name: "リンクスアシスト"
     module: "construction.sumitec_kanto_2"
@@ -3417,6 +3842,7 @@ sites:
     enabled: true
     terms_url: "https://sumitec-kanto.com/term"
 
+#426
   - site_id: ciic
     name: "CIIC"
     module: "government.ciic"
@@ -3425,6 +3851,7 @@ sites:
     enabled: true
     terms_url: "https://www.ciic.or.jp/ciic/privacy/"
 
+#427
   - site_id: hapisumu
     name: "ハピすむ（リフォーム加盟店）"
     module: "construction.hapisumu"
@@ -3433,6 +3860,7 @@ sites:
     enabled: true
     terms_url: "https://policy.bm-sms.co.jp/consumer/terms/hapisumu-jp"
 
+#428
   - site_id: gaiheki_madoguchi
     name: "外壁塗装の窓口"
     module: "construction.gaiheki_madoguchi"
@@ -3441,6 +3869,7 @@ sites:
     enabled: true
     terms_url: "https://gaiheki-madoguchi.com/rule"
 
+#429
   - site_id: lancers
     name: "サンラーズ"
     module: "service.lancers"
@@ -3449,6 +3878,7 @@ sites:
     enabled: true
     terms_url: "https://www.lancers.jp/help/terms?ref=footer"
 
+#430
   - site_id: jfnet
     name: "日本フードサービス協会"
     module: "corporate.jfnet"
@@ -3456,6 +3886,7 @@ sites:
     schedule: null
     enabled: true
 
+#431
   - site_id: soumu_2
     name: "電気通信事業者 登録・届出一覧"
     module: "government.soumu_2"
@@ -3463,6 +3894,7 @@ sites:
     schedule: null
     enabled: true
 
+#432
   - site_id: hotworks
     name: "HOTWORKS（山口）ホットワークス"
     module: "nightlife.hotworks"


### PR DESCRIPTION
432件の site_id 全てに #1〜#432 の連番コメントを追加し、エントリの識別を容易にする。

<!-- NetHarvest-Scripts プルリクエスト テンプレート -->

## 変更内容
<!-- 追加・変更したサイトや内容を簡潔に記載 -->

## 利用規約コンプライアンス（新規サイト追加・URL変更時は必須）
- [x] 対象サイトの利用規約を確認し、**スクレイピング / クローリング / ボット 等が禁止されていない**ことを確認した
- [x] `sites.yml` に **`terms_url`（利用規約ページのURL）** を設定した（不明・無い場合は空欄でも可、ただし手動確認は実施）
- [x] 規約禁止で削除済みのサイト（整体ナビ / グーネットピット / ゼヒトモ / フロム・エー / ジョブメドレー / ma_shienkikan / キタイシホン / 優良web）を **再追加していない**

## 動作確認
- [x] ローカルで `parse()` が想定どおり動作することを確認した

<!--
規約チェックの仕組み: terms_url を設定すると、スクレイプ開始前にシステムが規約を取得し、
禁止ワード検出時はスクレイプを中止して Teams 通知します。
詳細は README「サイト追加前の必須チェック」を参照。
-->
