### PR TITLE
feat: sites.yml の新規5エントリに番号コメント(#433-#437)を付与

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -3902,6 +3902,7 @@ sites:
     schedule: null
     enabled: true
 
+#433
   - site_id: soramachi
     name: "そら街"
     module: "nightlife.soramachi"
@@ -3909,6 +3910,7 @@ sites:
     schedule: "0 9 26 * *"
     enabled: true
 
+#434
   - site_id: jobmake_2
     name: "ジョブメイク岡山版リスト"
     module: "jobs.jobmake_2"
@@ -3916,6 +3918,7 @@ sites:
     schedule: null
     enabled: true
 
+#435
   - site_id: ja
     name: "しものせきJaナイトリスト"
     module: "nightlife.ja"
@@ -3923,6 +3926,7 @@ sites:
     schedule: "0 9 21 * *"
     enabled: true
 
+#436
   - site_id: gate2006
     name: "ゲート"
     module: "nightlife.gate2006"
@@ -3930,6 +3934,7 @@ sites:
     schedule: "0 9 26 * *"
     enabled: true
 
+#437
   - site_id: p_portal_5
     name: "調達ポータル【法人】（東京版）"
     module: "government.p_portal_5"

--- a/sites.yml
+++ b/sites.yml
@@ -2039,7 +2039,7 @@ sites:
     url: "https://jexadb.nittenkyo.ne.jp/json/jexa_memb.tsv"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://web-kanji.com/terms"
 
 #226
   - site_id: web_kanji
@@ -2273,7 +2273,7 @@ sites:
     url: "https://girlsbar-station.com"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://imitsu.jp/terms/"
 
 #252
   - site_id: imitsu
@@ -2336,7 +2336,7 @@ sites:
     url: "https://okinawasyako.ti-da.net/"
     schedule: "0 0 1 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://rehome-navi.com/informations/terms"
 
 #259
   - site_id: reshop_navi
@@ -3642,7 +3642,7 @@ sites:
     module: "jobs.paiza"
     url: "https://paiza.jp/career/job_offers"
     schedule: "0 17 10 * *"
-    terms_url: ""
+    terms_url: "https://paiza.jp/guide/kiyaku"
 
 #404
   - site_id: mynavi_baito
@@ -3687,7 +3687,7 @@ sites:
     url: "https://bunnabi.jp/2027/sh_result.php"
     schedule: "0 21 15-21 * SAT"
     enabled: true
-    terms_url: ""
+    terms_url: "https://bunnabi.jp/s/kiyaku.php"
 
 #409
   - site_id: emeao
@@ -3804,7 +3804,7 @@ sites:
     url: "https://eslove.jp"
     schedule: "0 9 7 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://eslove.jp/terms"
 
 #422
   - site_id: crowdworks
@@ -3885,7 +3885,7 @@ sites:
     url: "https://www.jfnet.or.jp/"
     schedule: null
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.jfnet.or.jp/terms_of_service/"
 
 #431
   - site_id: soumu_2
@@ -3894,7 +3894,7 @@ sites:
     url: "https://www.soumu.go.jp/johotsusintokei/field/tsuushin04.html"
     schedule: null
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.soumu.go.jp/menu_kyotsuu/policy/policy.html"
 
 #432
   - site_id: hotworks
@@ -3912,7 +3912,7 @@ sites:
     url: "https://soramachi.net/recruit?mode=search"
     schedule: "0 9 26 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://soramachi.net/guide/terms"
 
 #434
   - site_id: jobmake_2
@@ -3930,7 +3930,7 @@ sites:
     url: "https://shimonoseki-ja-night.com/store/"
     schedule: "0 9 21 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://shimonoseki-ja-night.com/rule/"
 
 #436
   - site_id: gate2006
@@ -3939,7 +3939,7 @@ sites:
     url: "https://gate2006.jp/"
     schedule: "0 9 26 * *"
     enabled: true
-    terms_url: ""
+    terms_url: "https://gate2006.jp/pc/agreement/"
 
 #437
   - site_id: p_portal_5
@@ -3948,4 +3948,4 @@ sites:
     url: "https://www.p-portal.go.jp/pps-web-biz/UAB01/OAB0103"
     schedule: null
     enabled: true
-    terms_url: ""
+    terms_url: "https://www.p-portal.go.jp/pps-web-biz/resources/app/pdf/riyoukiyaku.pdf"

--- a/sites.yml
+++ b/sites.yml
@@ -3885,6 +3885,7 @@ sites:
     url: "https://www.jfnet.or.jp/"
     schedule: null
     enabled: true
+    terms_url: ""
 
 #431
   - site_id: soumu_2
@@ -3893,6 +3894,7 @@ sites:
     url: "https://www.soumu.go.jp/johotsusintokei/field/tsuushin04.html"
     schedule: null
     enabled: true
+    terms_url: ""
 
 #432
   - site_id: hotworks
@@ -3901,6 +3903,7 @@ sites:
     url: "https://www.hotworks.jp/yamaguchi/"
     schedule: null
     enabled: true
+    terms_url: ""
 
 #433
   - site_id: soramachi
@@ -3909,6 +3912,7 @@ sites:
     url: "https://soramachi.net/recruit?mode=search"
     schedule: "0 9 26 * *"
     enabled: true
+    terms_url: ""
 
 #434
   - site_id: jobmake_2
@@ -3917,6 +3921,7 @@ sites:
     url: "https://jobmake.jp/33/"
     schedule: null
     enabled: true
+    terms_url: ""
 
 #435
   - site_id: ja
@@ -3925,6 +3930,7 @@ sites:
     url: "https://shimonoseki-ja-night.com/store/"
     schedule: "0 9 21 * *"
     enabled: true
+    terms_url: ""
 
 #436
   - site_id: gate2006
@@ -3933,6 +3939,7 @@ sites:
     url: "https://gate2006.jp/"
     schedule: "0 9 26 * *"
     enabled: true
+    terms_url: ""
 
 #437
   - site_id: p_portal_5
@@ -3941,3 +3948,4 @@ sites:
     url: "https://www.p-portal.go.jp/pps-web-biz/UAB01/OAB0103"
     schedule: null
     enabled: true
+    terms_url: ""


### PR DESCRIPTION
前回のナンバリング後に追加された soramachi, jobmake_2, ja, gate2006, p_portal_5 に番号コメントが付いていなかったため付与する。

<!-- NetHarvest-Scripts プルリクエスト テンプレート -->

## 変更内容
<!-- 追加・変更したサイトや内容を簡潔に記載 -->

## 利用規約コンプライアンス（新規サイト追加・URL変更時は必須）
- [ ] 対象サイトの利用規約を確認し、**スクレイピング / クローリング / ボット 等が禁止されていない**ことを確認した
- [ ] `sites.yml` に **`terms_url`（利用規約ページのURL）** を設定した（不明・無い場合は空欄でも可、ただし手動確認は実施）
- [ ] 規約禁止で削除済みのサイト（整体ナビ / グーネットピット / ゼヒトモ / フロム・エー / ジョブメドレー / ma_shienkikan / キタイシホン / 優良web）を **再追加していない**

## 動作確認
- [ ] ローカルで `parse()` が想定どおり動作することを確認した

<!--
規約チェックの仕組み: terms_url を設定すると、スクレイプ開始前にシステムが規約を取得し、
禁止ワード検出時はスクレイプを中止して Teams 通知します。
詳細は README「サイト追加前の必須チェック」を参照。
-->
