### PR TITLE
fix(jpon): 取りこぼしを検出・回収できるようにし、ウェイトをページ間に移す

### DIFF
--- a/sites/portal/jpon.py
+++ b/sites/portal/jpon.py
@@ -18,10 +18,21 @@
     python scripts/sites/portal/jpon.py
     python bin/run_flow.py --site-id jpon
 
+規模 (実測サンプリング 300ページに基づく):
+    - 町字ページ 307,463件 (47都道府県 / 1,897市区町村)
+    - 1ページ平均 25.5レコード → 全国 約780万レコード
+    - URLリストには 404 が約12%混在する (サイト側で消えたページ)
+
 注意:
     - サイトは過剰アクセスのレート制限を明示している。DELAY=3.0 推奨。
+      DELAY は「ページ取得の間隔」として _fetch() 内で適用する。
+      レコード単位で待つと 780万 × 3秒 = 270日規模になり完走できないため、
+      ITEM_DELAY = 0 で基底クラスのアイテム間ウェイトを無効化している。
     - ステルス対策として ブラウザ風 Accept-Language / Accept-Encoding 等を付与。
-    - 全国フル走査は 20-30万リクエスト規模。本番運用は段階的に。
+    - 取りこぼし対策: 各ページのサイト表示件数「全N」と抽出行数を突き合わせ、
+      一致したページのみ jpon_done.txt に記録する。不一致・通信失敗は
+      jpon_failed.txt に残り、同じコマンドの再実行で自動的に再試行される。
+    - 全国フルは DELAY=3.0 で約10.7日。中断しても再実行で続きから再開する。
 """
 
 import json
@@ -31,6 +42,9 @@ import time
 from pathlib import Path
 from typing import Generator
 from urllib.parse import urljoin
+
+import bs4
+import requests
 
 _project_root = Path(__file__).resolve().parent.parent.parent.parent
 if str(_project_root) not in sys.path:
@@ -42,14 +56,32 @@ from src.const.schema import Schema
 BASE_URL = "https://jpon.xyz"
 TOP_URL = "https://jpon.xyz/2012/index.html"
 
-_URL_CHECKPOINT = _project_root / "output" / "jpon_urls.json"
-_DONE_CHECKPOINT = _project_root / "output" / "jpon_done.txt"
+_OUTPUT_DIR = _project_root / "output"
+_URL_CHECKPOINT = _OUTPUT_DIR / "jpon_urls.json"
+# 取得と件数検証まで成功したページ（再実行時はスキップする）
+_DONE_CHECKPOINT = _OUTPUT_DIR / "jpon_done.txt"
+# 404 で恒久的に存在しないページ（スキップするが done とは区別して記録する）
+_GONE_CHECKPOINT = _OUTPUT_DIR / "jpon_404.txt"
+# 一時的な失敗・件数不一致（done に入れないので次回実行で自動リトライされる）
+_FAILED_CHECKPOINT = _OUTPUT_DIR / "jpon_failed.txt"
+# 件数不一致の詳細（サイト申告値と抽出値の突き合わせ結果）
+_MISMATCH_LOG = _OUTPUT_DIR / "jpon_mismatch.txt"
+
+# 1町字ページあたりの平均レコード数。全国300ページの実測サンプリングに基づく概算値で、
+# 進捗ログの ETA 分母にのみ使う（取得ロジックには影響しない）。
+# 町字ごとのばらつきが極端(0〜1,537件)なため、都道府県単位ではこの平均から大きく
+# 外れることがある。ETA はあくまで目安。
+_EST_RECORDS_PER_PAGE = 72.2
 
 # 表示文字列のスペース / タブ / 改行 / 全角スペースをまとめて正規化する
 _WHITESPACE_RE = re.compile(r"\s+")
 
 # /s/2012/{phone} 形式の href から完全な電話番号を取り出すための正規表現
 _PHONE_HREF_RE = re.compile(r"/s/\d+/(\d[\d\-]+)")
+
+# 町字ページに表示される件数サマリー「全440 ＋転入4 －転出15」の「全N」。
+# 取りこぼし検知に使う（サイト申告値と実際の抽出行数を突き合わせる）。
+_SITE_TOTAL_RE = re.compile(r"全([\d,]+)")
 
 
 def _clean(s) -> str:
@@ -58,11 +90,33 @@ def _clean(s) -> str:
     return _WHITESPACE_RE.sub(" ", str(s).replace("　", " ")).strip()
 
 
+def _load_checkpoint(path: Path) -> set[str]:
+    """1行1URL のチェックポイントファイルを集合として読み込む"""
+    if not path.exists():
+        return set()
+    with open(path, encoding="utf-8") as f:
+        return {line.strip() for line in f if line.strip()}
+
+
+def _append_lines(path: Path, lines: list[str]) -> None:
+    """チェックポイントファイルに追記する（空リストなら何もしない）"""
+    if not lines:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
 class JponScraper(StaticCrawler):
     """住所でポン! 2012年版 電話帳スクレイパー"""
 
-    # サイト側で「過剰なアクセスは規制」と明示しているため保守的に設定
+    # サイト側で「過剰なアクセスは規制」と明示しているため保守的に設定。
+    # このサイトでは DELAY = 「ページ取得の間隔」として使う（_fetch() 内で待機）。
     DELAY = 3.0
+
+    # 1町字ページから平均25件・最大460件ほど取れるため、アイテム単位で待つと
+    # 全国780万件 × 3秒 = 270日規模になり完走できない。待機はページ側に寄せる。
+    ITEM_DELAY = 0.0
 
     # ブラウザ風のヘッダーで bot 判定を回避（ステルス）
     USER_AGENT = (
@@ -72,8 +126,19 @@ class JponScraper(StaticCrawler):
 
     EXTRA_COLUMNS = ["市区町村", "町名", "エリアコード", "ステータス", "詳細URL"]
 
+    # --pref で1都道府県だけに絞って実行する場合に設定される (None = 全国)。
+    # 基底クラスが __init__ のオーバーライドを禁じているためクラス属性で持ち、
+    # 実行側から scraper.pref_id = "13" のように設定する。
+    pref_id: str | None = None
+
     def _setup(self):
         super()._setup()
+        # 直近に取得したページの状態（取りこぼし判定に使う）
+        self._page_error: str | None = None
+        self._page_expected: int | None = None
+        self._page_rows: int = 0
+        # 取得成功ページのサイト申告件数の合計。最終的な CSV 行数と突き合わせる
+        self.expected_total: int = 0
         # ブラウザらしい追加ヘッダーを送る（StaticCrawler ベースのステルス対策）
         self.session.headers.update({
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
@@ -90,14 +155,75 @@ class JponScraper(StaticCrawler):
             "Referer": f"{BASE_URL}/",
         })
 
+    # -------------------------------------------------------------------------
+    # 取得（ページ間ウェイト + ステータス判別）
+    # -------------------------------------------------------------------------
+
+    def _fetch(self, url: str) -> bs4.BeautifulSoup | None:
+        """ページ間ウェイトを入れて取得する。
+
+        基底の get_soup() はウェイトを持たず、404 と一時的な通信エラーを
+        どちらも None で返すため区別できない。取りこぼしを正しく扱うには
+        「恒久的に無いページ(404)」と「後で再試行すべき失敗」を分ける必要が
+        あるので、ここで直接セッションを叩いて status_code を保持する。
+
+        取得できなかった理由は self._page_error に入れる ("404" / "network: ..." 等)。
+        """
+        self._page_error = None
+        time.sleep(self.DELAY)
+        try:
+            response = self.session.get(url, timeout=self.TIMEOUT)
+        except requests.exceptions.RequestException as e:
+            self._page_error = f"network: {type(e).__name__}: {e}"
+            self.error_count += 1
+            self.logger.warning("通信エラー: %s — %s", url, e)
+            return None
+
+        if response.status_code == 404:
+            self._page_error = "404"
+            return None
+        if response.status_code != 200:
+            self._page_error = f"http {response.status_code}"
+            self.error_count += 1
+            self.logger.warning("HTTP %s: %s", response.status_code, url)
+            return None
+
+        # 文字化け対策（get_soup と同じ方針: ヘッダーの charset を優先）
+        content_type = response.headers.get("Content-Type", "")
+        if "charset=" not in content_type.lower():
+            response.encoding = response.apparent_encoding
+        return bs4.BeautifulSoup(response.text, "html.parser")
+
+    @property
+    def _url_checkpoint(self) -> Path:
+        """URL一覧チェックポイントのパス。
+
+        --pref 指定時は専用ファイルに分ける。全国用の jpon_urls.json に
+        1県分だけを保存してしまうと、次の全国実行がその部分リストを
+        「収集済み」として再利用し、残り46県を丸ごと取りこぼすため。
+        """
+        if self.pref_id:
+            return _OUTPUT_DIR / f"jpon_urls_pref{self.pref_id}.json"
+        return _URL_CHECKPOINT
+
     def parse(self, url: str) -> Generator[dict, None, None]:
+        url_checkpoint = self._url_checkpoint
+
         # 1-3. URL 収集 (チェックポイントがあればスキップ)
-        if _URL_CHECKPOINT.exists():
-            with open(_URL_CHECKPOINT, encoding="utf-8") as f:
+        if url_checkpoint.exists():
+            with open(url_checkpoint, encoding="utf-8") as f:
                 district_urls = json.load(f)
             self.logger.info("チェックポイントから町字URL %d件を読み込みました", len(district_urls))
         else:
             pref_urls = self._collect_prefecture_urls(url)
+            if self.pref_id:
+                wanted = f"/2012/{self.pref_id}/index.html"
+                pref_urls = [u for u in pref_urls if u.endswith(wanted)]
+                if not pref_urls:
+                    raise ValueError(
+                        f"--pref {self.pref_id} に対応する都道府県ページが見つかりません"
+                    )
+                self.logger.info("都道府県を絞り込み: pref_id=%s", self.pref_id)
             self.logger.info("都道府県数: %d", len(pref_urls))
 
             city_urls: list[str] = []
@@ -117,53 +243,152 @@ class JponScraper(StaticCrawler):
                     self.logger.warning("町字一覧取得失敗 %s: %s", city_url, e)
                     continue
 
-            _URL_CHECKPOINT.parent.mkdir(parents=True, exist_ok=True)
-            with open(_URL_CHECKPOINT, "w", encoding="utf-8") as f:
+            url_checkpoint.parent.mkdir(parents=True, exist_ok=True)
+            with open(url_checkpoint, "w", encoding="utf-8") as f:
                 json.dump(district_urls, f)
-            self.logger.info("URLチェックポイント保存: %d件 → %s", len(district_urls), _URL_CHECKPOINT)
+            self.logger.info("URLチェックポイント保存: %d件 → %s", len(district_urls), url_checkpoint)
 
-        # 完了済み町字URLをロードしてスキップ
-        done_urls: set[str] = set()
-        if _DONE_CHECKPOINT.exists() and _URL_CHECKPOINT.exists():
-            with open(_DONE_CHECKPOINT, encoding="utf-8") as f:
-                done_urls = {line.strip() for line in f if line.strip()}
-            self.logger.info("完了済み %d件 をスキップします", len(done_urls))
+        # 取得済み(= 件数検証まで通った)と 404 をスキップ対象としてロードする。
+        # 一時的な失敗は done に入れていないので、ここで自動的に再試行対象に戻る。
+        done_urls = _load_checkpoint(_DONE_CHECKPOINT)
+        gone_urls = _load_checkpoint(_GONE_CHECKPOINT)
+        skip_urls = done_urls | gone_urls
+        if skip_urls:
+            self.logger.info(
+                "スキップ: 取得済み %d件 + 404 %d件", len(done_urls), len(gone_urls)
+            )
 
-        remaining = [u for u in district_urls if u not in done_urls]
-        self.total_items = len(remaining)
-        self.logger.info("町字数 (= 取得対象ページ数): 全 %d件 / 残り %d件", len(district_urls), len(remaining))
+        remaining = [u for u in district_urls if u not in skip_urls]
+        # total_items はアイテム(レコード)数の分母として使われるため、
+        # ページ数ではなく推定レコード数を入れて ETA を意味のある値にする。
+        self.total_items = int(len(remaining) * _EST_RECORDS_PER_PAGE)
+        self.logger.info(
+            "町字ページ: 全 %d件 / 今回取得 %d件 (推定レコード数 約%s件)",
+            len(district_urls), len(remaining), f"{self.total_items:,}",
+        )
 
         # 4. 各町字 ?all で全件取得
         pending_done: list[str] = []
+        pending_gone: list[str] = []
+        pending_failed: list[str] = []
+        stats = {"pages": 0, "records": 0, "gone": 0, "failed": 0, "mismatch": 0}
+
         for district_url in remaining:
+            yielded = 0
             try:
-                yield from self._scrape_district(district_url)
+                for item in self._scrape_district(district_url):
+                    yielded += 1
+                    yield item
+                verdict = self._page_verdict(district_url, yielded)
             except Exception as e:
                 self.logger.warning("町字ページ取得失敗 %s: %s", district_url, e)
+                verdict = "failed"
 
-            pending_done.append(district_url)
+            stats["pages"] += 1
+            stats["records"] += yielded
+            if verdict == "done":
+                # サイト申告件数を積み上げる。ページ単位の照合では捕まえられない
+                # 「パイプライン側での行の取りこぼし」を最後に検出するために使う。
+                # (base.py はアイテム処理中の例外を CONTINUE_ON_ERROR で
+                #  スキップするため、yield した行が CSV に入らないことがある)
+                self.expected_total += self._page_expected or yielded
+                pending_done.append(district_url)
+            elif verdict == "gone":
+                pending_gone.append(district_url)
+                stats["gone"] += 1
+            else:
+                # 取得失敗・件数不一致は done に入れない → 次回実行で再試行される
+                pending_failed.append(district_url)
+                stats["failed"] += 1
+                if verdict == "mismatch":
+                    stats["mismatch"] += 1
+
             if len(pending_done) >= 100:
-                self._flush_done(pending_done)
+                _append_lines(_DONE_CHECKPOINT, pending_done)
                 pending_done.clear()
+            if len(pending_gone) >= 50:
+                _append_lines(_GONE_CHECKPOINT, pending_gone)
+                pending_gone.clear()
+            if len(pending_failed) >= 50:
+                _append_lines(_FAILED_CHECKPOINT, pending_failed)
+                pending_failed.clear()
 
-        if pending_done:
-            self._flush_done(pending_done)
+        _append_lines(_DONE_CHECKPOINT, pending_done)
+        _append_lines(_GONE_CHECKPOINT, pending_gone)
+        _append_lines(_FAILED_CHECKPOINT, pending_failed)
 
-        # 全件処理完了 — チェックポイントを削除
-        for p in (_URL_CHECKPOINT, _DONE_CHECKPOINT):
-            if p.exists():
-                p.unlink()
-        self.logger.info("全件処理完了。チェックポイントをクリアしました")
+        self.logger.info(
+            "今回処理: %s ページ / %s レコード（404 %s件 / 未取得 %s件 うち件数不一致 %s件）",
+            f"{stats['pages']:,}", f"{stats['records']:,}",
+            f"{stats['gone']:,}", f"{stats['failed']:,}", f"{stats['mismatch']:,}",
+        )
+
+        if stats["failed"]:
+            # 取りこぼしが残っているのでチェックポイントは消さない。
+            # 同じコマンドを再実行すれば失敗分だけを取得しにいく。
+            self.logger.warning(
+                "未取得 %s件 が残っています。チェックポイントは保持します。"
+                "同じコマンドを再実行すると未取得分のみ再試行します（一覧: %s）",
+                f"{stats['failed']:,}", _FAILED_CHECKPOINT,
+            )
+        elif self.pref_id:
+            # 1県のみの実行。done/404 は全国実行でもそのまま有効な記録なので消さない
+            # （消すと同じページを取り直すことになる）。URL一覧だけ片付ける。
+            if url_checkpoint.exists():
+                url_checkpoint.unlink()
+            self.logger.info(
+                "pref_id=%s の全ページ取得完了。done/404 の記録は全国実行に引き継ぎます",
+                self.pref_id,
+            )
+        else:
+            for p in (_URL_CHECKPOINT, _DONE_CHECKPOINT, _GONE_CHECKPOINT, _FAILED_CHECKPOINT):
+                if p.exists():
+                    p.unlink()
+            self.logger.info("全ページ取得完了。チェックポイントをクリアしました")
+
+    def _page_verdict(self, district_url: str, yielded: int) -> str:
+        """1ページの処理結果を判定する。
+
+        Returns:
+            "done"     — サイト申告件数と抽出件数が一致（取りこぼしなし）
+            "gone"     — 404。恒久的に存在しないのでスキップ対象に記録する
+            "mismatch" — 件数不一致。取りこぼしなので done にせず再試行させる
+            "failed"   — 通信エラー等
+        """
+        if self._page_error == "404":
+            return "gone"
+        if self._page_error is not None:
+            return "failed"
+
+        expected = self._page_expected
+        found = self._page_rows
+
+        # サマリー表示が無い/読めないページは突き合わせ不能。件数が取れていれば完了扱い。
+        if expected is None:
+            self.logger.debug("件数サマリーなし: %s (抽出 %d件)", district_url, found)
+            return "done"
+
+        if found != expected:
+            self.logger.warning(
+                "件数不一致 %s: サイト申告 全%d件 / 抽出 %d件 → 未取得として再試行対象にします",
+                district_url, expected, found,
+            )
+            _append_lines(
+                _MISMATCH_LOG, [f"{district_url}\texpected={expected}\tfound={found}"]
+            )
+            return "mismatch"
+
+        # 行は全部取れているが、名前が空でパイプラインに渡らなかった行がある場合
+        if yielded != found:
+            self.logger.warning(
+                "名前が空の行をスキップ %s: 行 %d件 中 %d件 のみ出力",
+                district_url, found, yielded,
+            )
+        return "done"
 
     # -------------------------------------------------------------------------
     # 階層別ヘルパー
     # -------------------------------------------------------------------------
-
-    @staticmethod
-    def _flush_done(urls: list[str]) -> None:
-        """処理済み町字URLをチェックポイントファイルに追記する"""
-        with open(_DONE_CHECKPOINT, "a", encoding="utf-8") as f:
-            f.write("\n".join(urls) + "\n")
 
     def _collect_prefecture_urls(self, top_url: str) -> list[str]:
         """トップ /2012/index.html から /2012/{pref_id}/index.html の URL を収集する"""
@@ -231,8 +456,15 @@ class JponScraper(StaticCrawler):
         return urls
 
     def _scrape_district(self, district_url: str) -> Generator[dict, None, None]:
-        """町字ページ ?all から全レコードを yield する"""
-        soup = self.get_soup(district_url)
+        """町字ページ ?all から全レコードを yield する。
+
+        取りこぼし検知のため、サイトが表示している件数「全N」を self._page_expected に、
+        実際に見つけた行数を self._page_rows に記録する。判定は _page_verdict() が行う。
+        """
+        self._page_expected = None
+        self._page_rows = 0
+
+        soup = self._fetch(district_url)
         if soup is None:
             return
 
@@ -252,8 +484,17 @@ class JponScraper(StaticCrawler):
         if m:
             area_code = f"{m.group(1)}-{m.group(2)}-{m.group(3)}"
 
+        # サイト表示の件数「全440 ＋転入4 －転出15」を取りこぼし検証用に記録する
+        m = _SITE_TOTAL_RE.search(soup.get_text(" ", strip=True))
+        if m:
+            self._page_expected = int(m.group(1).replace(",", ""))
+
         # 全 <tr itemtype="https://schema.org/Person"> を取得
-        rows = soup.select('tr[itemtype="https://schema.org/Person"]')
+        # itemtype は http:// 表記のページもあり得るため両方を対象にする
+        rows = soup.select(
+            'tr[itemtype="https://schema.org/Person"], tr[itemtype="http://schema.org/Person"]'
+        )
+        self._page_rows = len(rows)
         for tr in rows:
             try:
                 item = self._parse_row(tr, district_url, district_name, area_code)
@@ -365,6 +606,15 @@ if __name__ == "__main__":
         metavar="PARTIAL_CSV",
         help="中断された実行の一時CSVファイルを指定して最終CSVを復旧する",
     )
+    parser.add_argument(
+        "--pref",
+        metavar="PREF_ID",
+        help=(
+            "1都道府県だけを取得する (例: --pref 13)。段階的な本番投入や"
+            "試験実行に使う。全国は約13日かかるため、まず1県で通すことを推奨。"
+            "取得済み記録は全国実行にそのまま引き継がれる。"
+        ),
+    )
     args = parser.parse_args()
 
     if args.recover:
@@ -372,7 +622,22 @@ if __name__ == "__main__":
         sys.exit(0)
 
     scraper = JponScraper()
+    if args.pref:
+        scraper.pref_id = args.pref
+        scraper.site_name = f"jpon_pref{args.pref}"
+
     scraper.execute(TOP_URL)
 
     print(f"\n出力ファイル: {scraper.output_filepath}")
-    print(f"取得件数: {scraper.item_count}")
+    print(f"取得件数: {scraper.item_count:,}")
+
+    # 端から端までの取りこぼし検証:
+    # サイトが申告した件数の合計 == CSV に入った件数 なら欠損なし。
+    # ページ単位の照合だけでは、パイプライン側で行が落ちた場合を検出できない。
+    expected = scraper.expected_total
+    actual = scraper.item_count
+    print(f"サイト申告合計: {expected:,}")
+    if expected == actual:
+        print("✅ 取りこぼしなし (サイト申告件数と一致)")
+    else:
+        print(f"⚠ 差分 {expected - actual:+,} 件 — パイプライン側で行が落ちている可能性があります")


### PR DESCRIPTION
## 変更内容

住所でポン! (jpon.xyz) のクローラー修正です。既存サイトの修正で、新規サイト追加・URL変更はありません。

### 1. 完走できない待機設計を修正

`BaseCrawler` は **1 レコードごとに** `DELAY` 秒 sleep します。このサイトは 1 ページから平均 72 件 (最大 1,537 件) 取れるため、待機がレコード数に比例して膨れ上がっていました。

| ウェイトの置き場所 | 所要時間 |
|---|---|
| レコードごと (修正前) | 2,220万 × 3秒 = **約 771 日** |
| ページごと (修正後) | 307,463 × 3.97秒 = **約 14 日** |

`get_soup()` は元々ウェイトを持たないため、修正前は「**ページ取得は待ち0秒、レコード書き出しごとに3秒**」という意図と真逆の状態でした。サイト負荷の観点でも修正後の方が適切です。

`ITEM_DELAY = 0` で基底クラスのアイテム間ウェイトを無効化し、新設した `_fetch()` のページ取得直前で待機します。`ITEM_DELAY` は NetHarvest 側のPRで追加しています。

### 2. 静かなデータ欠損を修正

`parse()` は取得に失敗したページも無条件に done へ記録していました。

```python
try:
    yield from self._scrape_district(district_url)
except Exception as e:
    self.logger.warning(...)
pending_done.append(district_url)   # 失敗でも done 扱い
```

このためタイムアウトや 429 で落ちたページが「完了」として記録され、**再実行時に永久にスキップ**されていました。成功したページのみ done に記録し、結果を4分類にしました。

| 判定 | 記録先 | 再実行時 |
|---|---|---|
| 件数照合が通った | `jpon_done.txt` | スキップ |
| 404 | `jpon_404.txt` | スキップ |
| 件数不一致 | `jpon_failed.txt` + `jpon_mismatch.txt` | **再取得** |
| 通信エラー | `jpon_failed.txt` | **再取得** |

### 3. 取りこぼしの自動検出

各町字ページはサイト自身が件数を表示しています (例「全440 ＋転入4 －転出15」)。これと抽出行数を全ページで突き合わせ、一致したページのみ done にします。

加えて `expected_total` を追加しました。`base.py` はアイテム処理中の例外を `CONTINUE_ON_ERROR` で握って `continue` するため、パーサーが正しく取った行が CSV に入らないことがあり、この差はページ単位の照合では見えません。実行終了時に「サイト申告件数の合計 == CSV 行数」を判定して出力します。

### 4. 404 と一時エラーの区別

基底の `get_soup()` は 404 も通信エラーもどちらも `None` で返すため区別できません。404 を「後で再試行」に混ぜると永久にリトライし続けるため、`_fetch()` で `status_code` を保持するようにしました。URLリストには 404 が約 4.3% 混在しています。

### 5. `--pref` オプション

全国は約14日かかるため、1都道府県だけを取得できるようにしました。段階的な本番投入用です。

URL一覧は `jpon_urls_pref{N}.json` に分離しています。全国用の `jpon_urls.json` に1県分だけを保存すると、次の全国実行がその部分リストを「収集済み」として再利用し、**残り46県を丸ごと取りこぼす**ためです。done/404 の記録は全国実行にそのまま引き継がれます。

### 6. 進捗表示の分母を修正

`total_items` にページ数を入れていたため、進捗が `[レコード数 / ページ数]` という単位の異なる表示になっていました。推定レコード数に変更しました。

### 7. `itemtype` の `http://` 表記にも対応

## 利用規約コンプライアンス（新規サイト追加・URL変更時は必須）

既存サイトの取得ロジック修正のみで、新規サイト追加・URL変更はないため該当しません。なおサイトは「過剰に負荷をかけるアクセスは規制しています」と明示しており、`DELAY = 3.0` は据え置き、待機の置き場所のみを変更しています（上述のとおり、実際のページ取得間隔は修正後の方が長くなります）。

## 動作確認

- [x] ローカルで `parse()` が想定どおり動作することを確認した

| 検証項目 | 結果 |
|---|---|
| `?all` に打ち切りがないこと | **3/3 完全一致** — 最大1,537件のページで `?all` の行数 / `?p=1..16` 全巡回の合計 / サイト表示「全N」が一致 |
| 件数照合 | **287/287 一致**（全国300ページの系統サンプリング、成功ページ全件） |
| フィールド充填 | 名称・TEL・都道府県・住所すべて空欄ゼロ |
| verdict 判定 | 正常440件 / 大量1,537件 / 404 の3ケースで期待通り |
| 実走行 | 宮崎県 1,425ページで 3.97秒/ページを実測 |

## 規模（実測）

| 項目 | 値 |
|---|---|
| 町字ページ数 | 307,463 (47都道府県 / 1,897市区町村) |
| 1ページ平均 | 72.2 件（中央値 10 / 最大 1,537） |
| 全国推定レコード数 | 約 2,220 万件（95%信頼区間 1,581万〜2,858万） |
| 404率 | 約 4.3% |

## 補足: 電話番号の重複について

同一電話番号に複数レコードが存在します（2,540件中57番号）。実データを分類したところ**支店ではなく屋号と個人名の二重登録**が主体で、同一名称の重複は0件でした。

```
TEL 095-883-2664 (4行)  松尾 儀市 / 松尾ふとん店 / 松屋きもの着付教室 / 松屋呉服店
TEL 095-883-1661 (3行)  井川 敦子 / 井川 長年 / 井川内科医院
```

紙の電話帳が索引性のため1つの番号を複数の見出し語で載せていた実体です。電話番号だけをキーにした重複排除は情報が落ちるため非推奨です。

## 関連

`ITEM_DELAY` の追加は NetHarvest 側のPR: https://github.com/STREAM-inc/NetHarvest/pull/98

**このPRは NetHarvest#98 がマージされないと動きません**（`ITEM_DELAY` が未定義だと従来どおり `DELAY` が使われ、771日かかる状態に戻ります）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)